### PR TITLE
Fix for NPE from Jackson2 StdDeserializer in 2.9.0 + 2.9.1

### DIFF
--- a/enumerables-jackson2/pom.xml
+++ b/enumerables-jackson2/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <root.basedir>${project.parent.basedir}</root.basedir>
-        <jackson2.version>2.9.1</jackson2.version>
+        <jackson2.version>2.9.2</jackson2.version>
     </properties>
 
     <dependencies>

--- a/enumerables-jackson2/pom.xml
+++ b/enumerables-jackson2/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <root.basedir>${project.parent.basedir}</root.basedir>
-        <jackson2.version>2.8.8.1</jackson2.version>
+        <jackson2.version>2.9.1</jackson2.version>
     </properties>
 
     <dependencies>

--- a/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableDeserializer.java
+++ b/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableDeserializer.java
@@ -37,7 +37,7 @@ public class EnumerableDeserializer extends StdDeserializer<Enumerable> implemen
     }
 
     private EnumerableDeserializer(JavaType javaType) {
-        super(javaType);
+        super(javaType == null ? Enumerable.class : javaType.getRawClass());
         this.javaType = javaType;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -267,8 +267,10 @@
                             <docencoding>UTF-8</docencoding>
                             <useStandardDocletOptions>true</useStandardDocletOptions>
                             <additionalparam>
-                                -umlSkipStandardDoclet false
                                 -umlImageFormat SVG
+                                -umlImageDirectory images
+                                -umlCommand "hide empty fields"
+                                -umlCommand "hide empty methods"
                             </additionalparam>
                         </configuration>
                     </execution>


### PR DESCRIPTION
- [x] Reproduction through unit tests.
- [x] Fix and verify the tests pass again.
- [ ] Update Jackson dependency to 2.9.2 while we're at it.
