### PR TITLE
Jackson2: Make some serializer/deserializer methods accessible.

### DIFF
--- a/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableDeserializer.java
+++ b/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@ package nl.talsmasoftware.enumerables.jackson2;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import nl.talsmasoftware.enumerables.Enumerable;
@@ -42,7 +45,7 @@ public class EnumerableDeserializer extends StdDeserializer<Enumerable> implemen
         this.javaType = javaType;
     }
 
-    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         if (javaType == null) { // Are we the 'untyped' Enumerable deserializer?
             if (property != null && property.getType() != null) {
                 return new EnumerableDeserializer(property.getType());
@@ -109,7 +112,7 @@ public class EnumerableDeserializer extends StdDeserializer<Enumerable> implemen
         }
     }
 
-    private Enumerable parseObject(JsonParser jp, Class<? extends Enumerable> type) throws IOException {
+    protected Enumerable parseObject(JsonParser jp, Class<? extends Enumerable> type) throws IOException {
         Enumerable value = null;
         for (JsonToken nextToken = jp.nextToken(); nextToken != null; nextToken = jp.nextToken()) {
             switch (nextToken) {

--- a/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableSerializer.java
+++ b/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,10 @@ public class EnumerableSerializer extends StdSerializer<Enumerable> {
     private static final ConcurrentMap<String, List<BeanPropertyDefinition>> CACHE =
             new ConcurrentHashMap<String, List<BeanPropertyDefinition>>();
 
-    private final SerializationMethod serializationMethod;
+    /**
+     * The serialization method for enumerables.
+     */
+    protected final SerializationMethod serializationMethod;
 
     public EnumerableSerializer() {
         this(null);
@@ -67,7 +70,7 @@ public class EnumerableSerializer extends StdSerializer<Enumerable> {
         }
     }
 
-    private void serializeObject(Enumerable value, JsonGenerator jgen, SerializationConfig config) throws IOException {
+    protected void serializeObject(Enumerable value, JsonGenerator jgen, SerializationConfig config) throws IOException {
         jgen.writeStartObject();
         Class<? extends Enumerable> enumerableType = value.getClass();
         for (BeanPropertyDefinition property : serializationPropertiesFor(enumerableType, config)) {
@@ -81,7 +84,7 @@ public class EnumerableSerializer extends StdSerializer<Enumerable> {
         jgen.writeEndObject();
     }
 
-    private static List<BeanPropertyDefinition> serializationPropertiesFor(
+    protected static List<BeanPropertyDefinition> serializationPropertiesFor(
             Class<? extends Enumerable> enumerableType, SerializationConfig config) {
         final String cacheKey = enumerableType.getName();
         List<BeanPropertyDefinition> properties = CACHE.get(cacheKey);

--- a/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableSerializer.java
+++ b/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableSerializer.java
@@ -74,14 +74,20 @@ public class EnumerableSerializer extends StdSerializer<Enumerable> {
         jgen.writeStartObject();
         Class<? extends Enumerable> enumerableType = value.getClass();
         for (BeanPropertyDefinition property : serializationPropertiesFor(enumerableType, config)) {
-            if (property.couldSerialize()) {
-                final Object propertyValue = property.getAccessor().getValue(value);
-                if (propertyValue != null || property.isExplicitlyIncluded() || mustIncludeNull(config, enumerableType)) {
-                    jgen.writeObjectField(property.getName(), propertyValue);
-                }
-            }
+            serializeObjectProperty(property, value, jgen, config);
         }
         jgen.writeEndObject();
+    }
+
+    protected void serializeObjectProperty(
+            BeanPropertyDefinition property, Enumerable value, JsonGenerator jgen, SerializationConfig config)
+            throws IOException {
+        if (property.couldSerialize()) {
+            final Object propertyValue = property.getAccessor().getValue(value);
+            if (propertyValue != null || property.isExplicitlyIncluded() || mustIncludeNull(config, value.getClass())) {
+                jgen.writeObjectField(property.getName(), propertyValue);
+            }
+        }
     }
 
     protected static List<BeanPropertyDefinition> serializationPropertiesFor(


### PR DESCRIPTION
This makes the EnumerableModule a little more extensible,
which is needed by my client.