### PR TITLE
Jackson: Automatically register EnumerableModule.

### DIFF
--- a/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/Compatibility.java
+++ b/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,22 @@ package nl.talsmasoftware.enumerables.jackson2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.util.VersionUtil;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import nl.talsmasoftware.enumerables.Enumerable;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
+import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableCollection;
@@ -110,4 +116,46 @@ final class Compatibility {
         return javaType;
     }
 
+    private static transient Version moduleVersion = null;
+
+    static Version moduleVersion() {
+        if (moduleVersion == null) {
+            moduleVersion = mavenVersionFor("nl.talsmasoftware.enumerables", "enumerables-jackson2");
+        }
+        return moduleVersion;
+    }
+
+    /**
+     * Deprecated method copied from Jackson VersionUtil as this is exactly what we want :)
+     *
+     * @param groupId    The maven groupId of this module.
+     * @param artifactId The maven artifactId of this module.
+     * @return The version of this maven artifact.
+     */
+    private static Version mavenVersionFor(/*ClassLoader cl,*/ String groupId, String artifactId) {
+        String groupPath = groupId.replaceAll(Pattern.quote("."), "/");
+        String resource = "/META-INF/maven/" + groupPath + '/' + artifactId + "/pom.properties";
+        InputStream pomProperties = null;
+        try {
+            Properties props = new Properties();
+            props.load(pomProperties = Compatibility.class.getResourceAsStream(resource));
+            String versionStr = props.getProperty("version");
+            String pomPropertiesArtifactId = props.getProperty("artifactId");
+            String pomPropertiesGroupId = props.getProperty("groupId");
+            return VersionUtil.parseVersion(versionStr, pomPropertiesGroupId, pomPropertiesArtifactId);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINEST, "Exception ignored while loading maven version.", e);
+        } finally {
+            _close(pomProperties);
+        }
+        return Version.unknownVersion();
+    }
+
+    private static void _close(Closeable closeable) {
+        if (closeable != null) try {
+            closeable.close();
+        } catch (Exception closeEx) {
+            LOGGER.log(Level.FINEST, "Exception ignored while closing resource.", closeEx);
+        }
+    }
 }

--- a/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModule.java
+++ b/enumerables-jackson2/src/main/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import nl.talsmasoftware.enumerables.Enumerable;
 
-import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_STRING;
-
 /**
  * Mapping module for converting one or more {@link Enumerable} types to and from JSON using Jackson v2.
  *
@@ -31,7 +29,6 @@ import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_STRI
  */
 public class EnumerableModule extends SimpleModule {
 
-    private final SerializationMethod serializationMethod;
     private final EnumerableDeserializer deserializer = new EnumerableDeserializer();
 
     /**
@@ -45,15 +42,14 @@ public class EnumerableModule extends SimpleModule {
     /**
      * Constructor for custom {@link SerializationMethod} for {@link Enumerable} types.
      *
-     * @param serializationMethod The serialization method to use. This parameter may be {@code null} in which case the
-     *                            {@code AS_STRING} method will be used by default.
+     * @param serializationMethod The serialization method to use
+     *                            (optional, the EnumerableSerializer will choose a default otherwise).
      * @see SerializationMethod#AS_STRING
      * @see SerializationMethod#AS_OBJECT
      */
     public EnumerableModule(SerializationMethod serializationMethod) {
-        super("Enumerable mapping module");
-        this.serializationMethod = serializationMethod == null ? AS_STRING : serializationMethod;
-        super.addSerializer(Enumerable.class, new EnumerableSerializer(this.serializationMethod));
+        super("Enumerable mapping module", Compatibility.moduleVersion());
+        super.addSerializer(Enumerable.class, new EnumerableSerializer(serializationMethod));
         super.addDeserializer(Enumerable.class, this.deserializer);
     }
 
@@ -89,18 +85,18 @@ public class EnumerableModule extends SimpleModule {
 
     @Override
     public int hashCode() {
-        return serializationMethod.hashCode();
+        return version().hashCode();
     }
 
     @Override
     public boolean equals(Object other) {
         return this == other || (other instanceof EnumerableModule
-                && serializationMethod.equals(((EnumerableModule) other).serializationMethod));
+                && version().equals(((EnumerableModule) other).version()));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "{serializationMethod=" + serializationMethod + '}';
+        return getClass().getSimpleName();
     }
 
 }

--- a/enumerables-jackson2/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/enumerables-jackson2/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+nl.talsmasoftware.enumerables.jackson2.EnumerableModule

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/AutodetectModuleTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/AutodetectModuleTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.enumerables.jackson2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.cfg.ContextAttributes;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+public class AutodetectModuleTest {
+
+    private final ObjectMapper baseMapper = new ObjectMapper();
+    private final PlainTestObject subject = new PlainTestObject(PlainTestObject.BigCo.APPLE);
+
+    @Test
+    public void testDefaultObjectSerialization() throws JsonProcessingException, JSONException {
+        ObjectMapper mapper = baseMapper;
+        String expectedJson = "{\"bigCo\": {\"value\": \"Apple\"}}";
+        String actualJson = mapper.writeValueAsString(subject);
+        JSONAssert.assertEquals(expectedJson, actualJson, true);
+    }
+
+    @Test(expected = JsonMappingException.class)
+    public void testFailedDefaultDeserialization() throws IOException {
+        ObjectMapper mapper = baseMapper;
+        String json = "{\"bigCo\": {\"value\": \"Apple\"}}";
+        mapper.readValue(json, PlainTestObject.class);
+        fail("Missing deserializer exception expected.");
+    }
+
+    @Test
+    public void testAutodetectedSerialization() throws JsonProcessingException, JSONException {
+        ObjectMapper mapper = baseMapper.copy().findAndRegisterModules();
+        String expectedJson = "{\"bigCo\": \"Apple\"}";
+        String actualJson = mapper.writeValueAsString(subject);
+        JSONAssert.assertEquals(expectedJson, actualJson, true);
+    }
+
+    @Test
+    public void testAutodetectedDeserialization() throws IOException {
+        ObjectMapper mapper = baseMapper.copy().findAndRegisterModules();
+        String json1 = "{\"bigCo\": \"Apple\"}",
+                json2 = "{\"bigCo\": {\"value\": \"Apple\"}}";
+
+        assertThat(mapper.readValue(json1, PlainTestObject.class), is(equalTo(subject)));
+        assertThat(mapper.readValue(json2, PlainTestObject.class), is(equalTo(subject)));
+    }
+
+    @Test
+    public void testAutodetectedSerializationAsObject() throws JsonProcessingException, JSONException {
+        ObjectMapper mapper = baseMapper.copy().findAndRegisterModules();
+
+        // Reconfigure the mapper to serialize only BigCo types as JSON object. All other Enumerables as Strings.
+        SerializationMethod serializationMethod = SerializationMethod.AS_STRING.except(PlainTestObject.BigCo.class);
+        mapper = mapper.setConfig(mapper.getSerializationConfig()
+                .with(ContextAttributes.getEmpty().withSharedAttribute(SerializationMethod.class.getName(), serializationMethod)));
+
+        String expectedJson = "{\"bigCo\": {\"value\": \"Apple\"}}";
+        String actualJson = mapper.writeValueAsString(subject);
+        JSONAssert.assertEquals(expectedJson, actualJson, true);
+    }
+
+    @Test
+    public void testAutodetectedAsObjectFromExplicitWriter() throws JsonProcessingException, JSONException {
+        // Create a writer that serializes only BigCo types to JSON objects. All other Enumerables as strings.
+        ObjectWriter writer = baseMapper.copy().findAndRegisterModules()
+                .writer(ContextAttributes.getEmpty().withSharedAttribute(
+                        SerializationMethod.class.getName(),
+                        SerializationMethod.AS_STRING.except(PlainTestObject.BigCo.class)));
+
+        String expectedJson = "{\"bigCo\": {\"value\": \"Apple\"}}";
+        String actualJson = writer.writeValueAsString(subject);
+        JSONAssert.assertEquals(expectedJson, actualJson, true);
+    }
+}

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModuleTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModuleTest.java
@@ -191,7 +191,7 @@ public class EnumerableModuleTest {
 
     @Test
     public void testToString() {
-        assertThat(module, hasToString("EnumerableModule{serializationMethod=As string}"));
+        assertThat(module, hasToString("EnumerableModule"));
     }
 
     @Test
@@ -212,8 +212,8 @@ public class EnumerableModuleTest {
         assertThat(set.add(module), is(true));
         assertThat(set.add(module), is(false));
         assertThat(set.add(new EnumerableModule(AS_STRING)), is(false));
-        assertThat(set.add(new EnumerableModule(AS_OBJECT)), is(true));
-        assertThat(set.add(new EnumerableModule(AS_STRING.except(BigCo.class))), is(true));
-        assertThat(set, hasSize(3));
+        assertThat(set.add(new EnumerableModule(AS_OBJECT)), is(false));
+        assertThat(set.add(new EnumerableModule(AS_STRING.except(BigCo.class))), is(false));
+        assertThat(set, hasSize(1));
     }
 }


### PR DESCRIPTION
- This enables use via `new ObjectMapper().findAndRegisterModules()`.
- Allow custom serialization methods for subtypes through the
  `nl.talsmasoftware.enumerables.jackson2.SerializationMethod`
  attribute (added tests verifying this).
- By the way; added maven version detection to Jackson module

This fixes #47