### PR TITLE
Expose 'simple' swagger model for enumerables.

### DIFF
--- a/enumerables-swagger/src/main/resources/nl/talsmasoftware/enumerables/swagger/EnumerableModel.properties
+++ b/enumerables-swagger/src/main/resources/nl/talsmasoftware/enumerables/swagger/EnumerableModel.properties
@@ -1,0 +1,1 @@
+description = {0} with known values {1}

--- a/enumerables-swagger/src/main/resources/nl/talsmasoftware/enumerables/swagger/EnumerableModel_nl.properties
+++ b/enumerables-swagger/src/main/resources/nl/talsmasoftware/enumerables/swagger/EnumerableModel_nl.properties
@@ -1,0 +1,1 @@
+description = {0} met bekende waarden {1}

--- a/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/EnumerableModelConverterTest.java
+++ b/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/EnumerableModelConverterTest.java
@@ -21,16 +21,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.converter.ModelConverters;
 import io.swagger.models.Model;
 import org.json.JSONException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.instanceOf;
 
 public class EnumerableModelConverterTest {
 
@@ -39,6 +37,18 @@ public class EnumerableModelConverterTest {
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     final EnumerableModelConverter converter = new EnumerableModelConverter();
+
+    static Locale previousDefault;
+
+    @BeforeClass
+    public static void captureDefaultLocale() {
+        previousDefault = Locale.getDefault();
+    }
+
+    @AfterClass
+    public static void restoreDefaultLocale() {
+        Locale.setDefault(previousDefault);
+    }
 
     @Before
     public void setUp() {
@@ -52,11 +62,7 @@ public class EnumerableModelConverterTest {
 
     @Test
     public void testSwaggerModelForCar() throws JsonProcessingException, JSONException {
-        // To test with example rendered as a JSON object:
-//        ObjectMapper mapper = this.mapper.setConfig(this.mapper.getSerializationConfig()
-//                .with(ContextAttributes.getEmpty()
-//                        .withSharedAttribute(SerializationMethod.class.getName(), SerializationMethod.AS_OBJECT)));
-
+        Locale.setDefault(Locale.ENGLISH);
         String expectedCarModel = "{" +
                 "\"type\": \"object\"," +
                 "\"properties\": {" +
@@ -66,11 +72,8 @@ public class EnumerableModelConverterTest {
 
         String expectedCarBrandModel = "{" +
                 "\"type\": \"string\", " +
-                "\"name\": \"CarBrand\", " +
-                "\"simple\": true, " +
-                "\"enum\": [\"Tesla\", \"Uniti Sweden\"], " +
-                "\"description\": \"Known CarBrand values, although unknown values are also allowed.\", " +
-                "\"example\": \"Tesla\", " +
+                "\"format\": \"enumerable\", " +
+                "\"description\": \"CarBrand with known values [Tesla, Uniti Sweden]\", " +
                 "\"externalDocs\": {\"description\": \"Enumerables\", \"url\": \"https://github.com/talsma-ict/enumerables\"}" +
                 "}";
 
@@ -81,7 +84,6 @@ public class EnumerableModelConverterTest {
         JSONAssert.assertEquals(expectedCarModel, mapper.writeValueAsString(swagger.get("Car")), true);
 
         assertThat(swagger, hasKey("CarBrand"));
-        assertThat(swagger.get("CarBrand"), instanceOf(EnumerableModel.class));
         JSONAssert.assertEquals(expectedCarBrandModel, mapper.writeValueAsString(swagger.get("CarBrand")), true);
     }
 

--- a/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/SwaggerModelWithoutConverterTest.java
+++ b/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/SwaggerModelWithoutConverterTest.java
@@ -69,7 +69,6 @@ public class SwaggerModelWithoutConverterTest {
         JSONAssert.assertEquals(expectedCarModel, mapper.writeValueAsString(swagger.get("Car")), true);
 
         assertThat(swagger, hasKey("CarBrand"));
-        assertThat(swagger.get("CarBrand"), instanceOf(ModelImpl.class));
         JSONAssert.assertEquals(expectedCarBrandModel, mapper.writeValueAsString(swagger.get("CarBrand")), true);
     }
 


### PR DESCRIPTION
They aren't technically enums and confusing them as such may cause
unwanted validation issues for unknown values.
Known values are documented in the description field of the Model
(currently limited to max 25 values).

This fixes #51.