### PR TITLE
Add JdbiPlugin implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 dist: trusty
+git:
+  depth: false
 
 language: java
 jdk:

--- a/enumerables-jdbi3/src/main/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPlugin.java
+++ b/enumerables-jdbi3/src/main/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.enumerables.jdbi3;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.argument.Arguments;
+import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+/**
+ * {@link JdbiPlugin JDBI plugin} that registers mappers for {@code Enumerable} subclasses.
+ * <p>
+ * This plugin registers itself when {@link Jdbi#installPlugins()} gets called,
+ * bug can also be explicitly installed using {@link Jdbi#installPlugin(JdbiPlugin)}.
+ *
+ * @author Sjoerd Talsma
+ */
+public class EnumerableJdbiPlugin implements JdbiPlugin {
+
+    /**
+     * Registers the {@link EnumerableArgumentFactory} and {@link EnumerableColumnMapperFactory} with the provided
+     * {@link Jdbi} instance.
+     *
+     * @param jdbi The JDBI instance to register the Enumerable mappings for.
+     */
+    @Override
+    public void customizeJdbi(Jdbi jdbi) {
+        jdbi.getConfig(Arguments.class).register(new EnumerableArgumentFactory());
+        jdbi.getConfig(ColumnMappers.class).register(new EnumerableColumnMapperFactory());
+    }
+
+}

--- a/enumerables-jdbi3/src/main/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPlugin.java
+++ b/enumerables-jdbi3/src/main/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPlugin.java
@@ -34,7 +34,7 @@ public class EnumerableJdbiPlugin implements JdbiPlugin {
      * Registers the {@link EnumerableArgumentFactory} and {@link EnumerableColumnMapperFactory} with the provided
      * {@link Jdbi} instance.
      *
-     * @param jdbi The JDBI instance to register the Enumerable mappings for.
+     * @param jdbi The JDBI instance to register the {@code Enumerable} mappings for.
      */
     @Override
     public void customizeJdbi(Jdbi jdbi) {

--- a/enumerables-jdbi3/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
+++ b/enumerables-jdbi3/src/main/resources/META-INF/services/org.jdbi.v3.core.spi.JdbiPlugin
@@ -1,0 +1,1 @@
+nl.talsmasoftware.enumerables.jdbi3.EnumerableJdbiPlugin

--- a/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/Car.java
+++ b/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/Car.java
@@ -21,6 +21,7 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Objects;
 
 public class Car {
 
@@ -41,15 +42,10 @@ public class Car {
     @Override
     public boolean equals(Object other) {
         return this == other || (other instanceof Car
-                && equals(this.brand, ((Car) other).brand)
-                && equals(this.type, ((Car) other).type)
-                && equals(this.productionYear, ((Car) other).productionYear)
+                && Objects.equals(this.brand, ((Car) other).brand)
+                && Objects.equals(this.type, ((Car) other).type)
+                && Objects.equals(this.productionYear, ((Car) other).productionYear)
         );
-    }
-
-    // because.. java 5
-    private static boolean equals(Object a, Object b) {
-        return a == b || (a != null && a.equals(b));
     }
 
     public static class Mapper implements RowMapper<Car> {
@@ -59,4 +55,5 @@ public class Car {
             return delegate.map(rs, ctx);
         }
     }
+
 }

--- a/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/CarDao.java
+++ b/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/CarDao.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.enumerables.jdbi3;
+
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+
+import java.util.List;
+
+/**
+ * DAO that uses automatically installed JDBI plugin instead of registered factories
+ */
+public interface CarDao {
+
+    @SqlQuery("select brand, type, productionYear " +
+            "from   cars " +
+            "where  (:brand is null or brand = :brand) " +
+            "and    (:type is null or type = :type)")
+    @UseRowMapper(Car.Mapper.class)
+    List<Car> findCars(@Bind("brand") CarBrand brand, @Bind("type") String type);
+
+}

--- a/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPluginTest.java
+++ b/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPluginTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2018 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.enumerables.jdbi3;
+
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * @author Sjoerd Talsma
+ */
+public class EnumerableJdbiPluginTest {
+
+    static DataSource dataSource = JdbcConnectionPool.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "user", "pwd");
+
+    @AfterClass
+    public static void shutdownDataSource() {
+        ((JdbcConnectionPool) dataSource).dispose();
+    }
+
+    @Before
+    public void prepareTestdata() throws SQLException {
+        Connection connection = null;
+        Statement statement = null;
+        try {
+            connection = dataSource.getConnection();
+            statement = connection.createStatement();
+            statement.execute("create table if not exists cars (brand varchar(255), type varchar(255), productionYear int)");
+            statement.execute("delete from cars");
+            statement.execute("insert into cars (brand, type, productionYear) values ('Jaguar', 'XK', 2006)");
+            statement.execute("insert into cars (brand, type, productionYear) values ('Tesla', 'Model S', 2015)");
+        } finally {
+            if (statement != null) statement.close();
+            if (connection != null) connection.close();
+        }
+    }
+
+    // TODO Add test with Jdbi.installPlugins() to verify automatic registration.
+
+}


### PR DESCRIPTION
Currently, the argument factory and column mapper factory have to be registered manually.
Adding a single JDBI plugin that self registers them on `Jdbi.installPlugins()` make things easier.