### PR TITLE
JavaDoc: Use UML doclet version 2 (requires JDK 9)

### DIFF
--- a/enumerables-jdbi/src/main/java/nl/talsmasoftware/enumerables/jdbi/EnumerableArgumentFactory.java
+++ b/enumerables-jdbi/src/main/java/nl/talsmasoftware/enumerables/jdbi/EnumerableArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  *      public interface MyDao {
  *          ...
  *         {@literal @}SqlQuery("select ... as obj from ...  where type = :type")
- *          List&lt;MyValueObject> queryWithType({@literal @}Bind("type") MyTypeEnumerable type);
+ *          List&lt;MyValueObject&gt; queryWithType({@literal @}Bind("type") MyTypeEnumerable type);
  *          ...
  *      }
  * </pre>

--- a/enumerables-jdbi3/src/main/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableArgumentFactory.java
+++ b/enumerables-jdbi3/src/main/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableArgumentFactory.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  *      public interface MyDao {
  *          ...
  *         {@literal @}SqlQuery("select ... as obj from ...  where type = :type")
- *          List&lt;MyValueObject> queryWithType({@literal @}Bind("type") MyTypeEnumerable type);
+ *          List&lt;MyValueObject&gt; queryWithType({@literal @}Bind("type") MyTypeEnumerable type);
  *          ...
  *      }
  * </pre>

--- a/enumerables/src/main/java/nl/talsmasoftware/enumerables/Enumerable.java
+++ b/enumerables/src/main/java/nl/talsmasoftware/enumerables/Enumerable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,6 @@ import static java.util.Collections.*;
  * <p>
  * TODO: Talk about values(), ordinal(), and other enum concepts.
  * TODO: Document an example of how using it.
- * <p>
- * Here is a generated UML class diagram for this core <code>Enumerable</code> class:<br>
- * <center><img src="package.svg" alt="Class diagram of enumerables package"></center>
  *
  * @author Sjoerd Talsma
  */

--- a/enumerables/src/main/java/nl/talsmasoftware/enumerables/package-info.java
+++ b/enumerables/src/main/java/nl/talsmasoftware/enumerables/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Talsma ICT
+ * Copyright 2016-2018 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@
  * but also offers a possibility to represent <em>yet unknown additional values</em> by parsing them.
  * In fact; parsing a known value results in the single constant reference.
  * Same goes for serialization and deserialization.
- * <p>
- * Class diagram for this package:<br><center><img src="package.svg" alt="package class diagram"></center>
  *
  * @author Sjoerd Talsma
  */

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
-        <umldoclet.version>1.0.18</umldoclet.version>
+        <umldoclet.version>2.0.0-rc.2</umldoclet.version>
     </properties>
 
     <dependencies>
@@ -275,20 +275,15 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
+                            <jdkToolchain>
+                                <version>9</version>
+                            </jdkToolchain>
                             <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
                             <docletArtifact>
                                 <groupId>nl.talsmasoftware</groupId>
                                 <artifactId>umldoclet</artifactId>
                                 <version>${umldoclet.version}</version>
                             </docletArtifact>
-                            <docencoding>UTF-8</docencoding>
-                            <useStandardDocletOptions>true</useStandardDocletOptions>
-                            <additionalOptions>
-                                <additionalOption>-umlImageFormat SVG</additionalOption>
-                                <additionalOption>-umlImageDirectory images</additionalOption>
-                                <additionalOption>-umlCommand "hide empty fields"</additionalOption>
-                                <additionalOption>-umlCommand "hide empty methods"</additionalOption>
-                            </additionalOptions>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Also remove manually included UML diagrams, as they are automatically included in the HTML
by the new doclet. This also allows linking from the UML.

When merged, this fixes #78