### PR TITLE
Switch to jUnit Jupiter and AssertJ.

### DIFF
--- a/enumerables-gson/src/test/java/nl/talsmasoftware/enumerables/gson/EnumerableTypeAdapterFactoryTest.java
+++ b/enumerables-gson/src/test/java/nl/talsmasoftware/enumerables/gson/EnumerableTypeAdapterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,45 +15,41 @@
  */
 package nl.talsmasoftware.enumerables.gson;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import static nl.talsmasoftware.enumerables.gson.SerializationMethod.AS_OBJECT;
 import static nl.talsmasoftware.enumerables.gson.SerializationMethod.AS_STRING;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class EnumerableTypeAdapterFactoryTest {
+class EnumerableTypeAdapterFactoryTest {
 
     @Test
-    public void testHashcodeEquals() {
+    void testHashcodeEquals() {
         EnumerableTypeAdapterFactory factory = new EnumerableTypeAdapterFactory(null);
         Set<EnumerableTypeAdapterFactory> set = new HashSet<EnumerableTypeAdapterFactory>();
-        assertThat(set.add(factory), is(true));
-        assertThat(set.add(factory), is(false));
-        assertThat(set.add(new EnumerableTypeAdapterFactory(AS_STRING)), is(false));
-        assertThat(set.add(new EnumerableTypeAdapterFactory(AS_OBJECT)), is(true));
-        assertThat(set.add(new EnumerableTypeAdapterFactory(AS_STRING.except(Car.Brand.class))), is(true));
-        assertThat(set, hasSize(3));
+        assertThat(set.add(factory)).isTrue();
+        assertThat(set.add(factory)).isFalse();
+        assertThat(set.add(new EnumerableTypeAdapterFactory(AS_STRING))).isFalse();
+        assertThat(set.add(new EnumerableTypeAdapterFactory(AS_OBJECT))).isTrue();
+        assertThat(set.add(new EnumerableTypeAdapterFactory(AS_STRING.except(Car.Brand.class)))).isTrue();
+        assertThat(set).hasSize(3);
     }
 
     @Test
-    public void testToString() {
-        assertThat(new EnumerableTypeAdapterFactory(null),
-                hasToString(equalTo("EnumerableTypeAdapterFactory{As string}")));
-        assertThat(new EnumerableTypeAdapterFactory(AS_STRING),
-                hasToString(equalTo("EnumerableTypeAdapterFactory{As string}")));
-        assertThat(new EnumerableTypeAdapterFactory(AS_OBJECT),
-                hasToString(equalTo("EnumerableTypeAdapterFactory{As object}")));
-        assertThat(new EnumerableTypeAdapterFactory(AS_OBJECT.except(Car.Brand.class)),
-                hasToString(equalTo("EnumerableTypeAdapterFactory{As object, except [Car$Brand]}")));
+    void testToString() {
+        assertThat(new EnumerableTypeAdapterFactory(null))
+                .hasToString("EnumerableTypeAdapterFactory{As string}");
+        assertThat(new EnumerableTypeAdapterFactory(AS_STRING))
+                .hasToString("EnumerableTypeAdapterFactory{As string}");
+        assertThat(new EnumerableTypeAdapterFactory(AS_OBJECT))
+                .hasToString("EnumerableTypeAdapterFactory{As object}");
+        assertThat(new EnumerableTypeAdapterFactory(AS_OBJECT.except(Car.Brand.class)))
+                .hasToString("EnumerableTypeAdapterFactory{As object, except [Car$Brand]}");
     }
 }

--- a/enumerables-gson/src/test/java/nl/talsmasoftware/enumerables/gson/GsonEnumerablesTest.java
+++ b/enumerables-gson/src/test/java/nl/talsmasoftware/enumerables/gson/GsonEnumerablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,70 +15,68 @@
  */
 package nl.talsmasoftware.enumerables.gson;
 
-import org.junit.Test;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import static nl.talsmasoftware.enumerables.gson.SerializationMethod.AS_OBJECT;
 import static nl.talsmasoftware.enumerables.gson.SerializationMethod.AS_STRING;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Sjoerd Talsma
  */
-public class GsonEnumerablesTest {
+class GsonEnumerablesTest {
 
     @Test
-    public void testConfigureNulls() {
-        assertThat(GsonEnumerables.configureGsonBuilder(null, null), is(nullValue()));
+    void testConfigureNulls() {
+        assertThat(GsonEnumerables.configureGsonBuilder(null, null)).isNull();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUnsupportedConstructor() throws Throwable {
+    @Test
+    void testUnsupportedConstructor() throws Throwable {
         Constructor<GsonEnumerables> constructor = GsonEnumerables.class.getDeclaredConstructor();
         try {
-            assertThat(constructor.isAccessible(), is(false));
+            assertThat(constructor.isAccessible()).isFalse();
             constructor.setAccessible(true);
-            constructor.newInstance();
-            fail("Exception expected.");
-        } catch (InvocationTargetException ite) {
-            throw ite.getCause();
+            assertThatThrownBy(constructor::newInstance)
+                    .isInstanceOf(InvocationTargetException.class)
+                    .cause()
+                    .isInstanceOf(UnsupportedOperationException.class);
         } finally {
             constructor.setAccessible(false);
         }
     }
 
     @Test
-    public void testDefaultGsonBuilder() {
-        assertThat(GsonEnumerables.defaultGsonBuilder(), is(notNullValue()));
-        assertThat(GsonEnumerables.defaultGsonBuilder().create(), is(notNullValue()));
-        assertThat(GsonEnumerables.defaultGsonBuilder().create().toJson(Car.Brand.AUDI), is(equalTo("\"Audi\"")));
+    void testDefaultGsonBuilder() {
+        GsonBuilder builder = GsonEnumerables.defaultGsonBuilder();
+        assertThat(builder).isNotNull();
+        assertThat(builder.create()).isNotNull();
+        assertThat(builder.create().toJson(Car.Brand.AUDI)).isEqualTo("\"Audi\"");
     }
 
     @Test
-    public void testCreateGsonBuilder() {
+    void testCreateGsonBuilder() {
         // default serialization
-        assertThat(GsonEnumerables.createGsonBuilder(null), is(notNullValue()));
-        assertThat(GsonEnumerables.createGsonBuilder(null).create(), is(notNullValue()));
-        assertThat(GsonEnumerables.createGsonBuilder(null).create().toJson(Car.Brand.AUDI),
-                is(equalTo("\"Audi\"")));
+        assertThat(GsonEnumerables.createGsonBuilder(null)).isNotNull();
+        assertThat(GsonEnumerables.createGsonBuilder(null).create()).isNotNull();
+        assertThat(GsonEnumerables.createGsonBuilder(null).create().toJson(Car.Brand.AUDI))
+                .isEqualTo("\"Audi\"");
 
         // String serialization == default
-        assertThat(GsonEnumerables.createGsonBuilder(AS_STRING).create().toJson(Car.Brand.AUDI),
-                is(equalTo("\"Audi\"")));
+        assertThat(GsonEnumerables.createGsonBuilder(AS_STRING).create().toJson(Car.Brand.AUDI))
+                .isEqualTo("\"Audi\"");
 
         // Object serialization
-        assertThat(GsonEnumerables.createGsonBuilder(AS_OBJECT).create().toJson(Car.Brand.AUDI),
-                is(equalTo("{\"value\":\"Audi\"}")));
+        assertThat(GsonEnumerables.createGsonBuilder(AS_OBJECT).create().toJson(Car.Brand.AUDI))
+                .isEqualTo("{\"value\":\"Audi\"}");
 
         // Object serialization with exception
-        assertThat(GsonEnumerables.createGsonBuilder(AS_OBJECT.except(Car.Brand.class)).create().toJson(Car.Brand.AUDI),
-                is(equalTo("\"Audi\"")));
+        assertThat(GsonEnumerables.createGsonBuilder(AS_OBJECT.except(Car.Brand.class)).create().toJson(Car.Brand.AUDI))
+                .isEqualTo("\"Audi\"");
     }
 }

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/AutodetectModuleTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/AutodetectModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,39 +21,37 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class AutodetectModuleTest {
+class AutodetectModuleTest {
 
     private final ObjectMapper baseMapper = new ObjectMapper();
     private final PlainTestObject subject = new PlainTestObject(PlainTestObject.BigCo.APPLE);
 
     @Test
-    public void testDefaultObjectSerialization() throws JsonProcessingException, JSONException {
+    void testDefaultObjectSerialization() throws JsonProcessingException, JSONException {
         ObjectMapper mapper = baseMapper;
         String expectedJson = "{\"bigCo\": {\"value\": \"Apple\"}}";
         String actualJson = mapper.writeValueAsString(subject);
         JSONAssert.assertEquals(expectedJson, actualJson, true);
     }
 
-    @Test(expected = JsonMappingException.class)
-    public void testFailedDefaultDeserialization() throws IOException {
+    @Test
+    void testFailedDefaultDeserialization() {
         ObjectMapper mapper = baseMapper;
         String json = "{\"bigCo\": {\"value\": \"Apple\"}}";
-        mapper.readValue(json, PlainTestObject.class);
-        fail("Missing deserializer exception expected.");
+        assertThatThrownBy(() -> mapper.readValue(json, PlainTestObject.class))
+                .isInstanceOf(JsonMappingException.class);
     }
 
     @Test
-    public void testAutodetectedSerialization() throws JsonProcessingException, JSONException {
+    void testAutodetectedSerialization() throws JsonProcessingException, JSONException {
         ObjectMapper mapper = baseMapper.copy().findAndRegisterModules();
         String expectedJson = "{\"bigCo\": \"Apple\"}";
         String actualJson = mapper.writeValueAsString(subject);
@@ -61,17 +59,17 @@ public class AutodetectModuleTest {
     }
 
     @Test
-    public void testAutodetectedDeserialization() throws IOException {
+    void testAutodetectedDeserialization() throws IOException {
         ObjectMapper mapper = baseMapper.copy().findAndRegisterModules();
         String json1 = "{\"bigCo\": \"Apple\"}",
                 json2 = "{\"bigCo\": {\"value\": \"Apple\"}}";
 
-        assertThat(mapper.readValue(json1, PlainTestObject.class), is(equalTo(subject)));
-        assertThat(mapper.readValue(json2, PlainTestObject.class), is(equalTo(subject)));
+        assertThat(mapper.readValue(json1, PlainTestObject.class)).isEqualTo(subject);
+        assertThat(mapper.readValue(json2, PlainTestObject.class)).isEqualTo(subject);
     }
 
     @Test
-    public void testAutodetectedSerializationAsObject() throws JsonProcessingException, JSONException {
+    void testAutodetectedSerializationAsObject() throws JsonProcessingException, JSONException {
         ObjectMapper mapper = baseMapper.copy().findAndRegisterModules();
 
         // Reconfigure the mapper to serialize only BigCo types as JSON object. All other Enumerables as Strings.
@@ -85,7 +83,7 @@ public class AutodetectModuleTest {
     }
 
     @Test
-    public void testAutodetectedAsObjectFromExplicitWriter() throws JsonProcessingException, JSONException {
+    void testAutodetectedAsObjectFromExplicitWriter() throws JsonProcessingException, JSONException {
         // Create a writer that serializes only BigCo types to JSON objects. All other Enumerables as strings.
         ObjectWriter writer = baseMapper.copy().findAndRegisterModules()
                 .writer(ContextAttributes.getEmpty().withSharedAttribute(

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/CompatibilityTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/CompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,14 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import nl.talsmasoftware.enumerables.jackson2.PlainTestObject.BigCo;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -38,10 +35,10 @@ import static org.mockito.Mockito.when;
 /**
  * @author Sjoerd Talsma
  */
-public class CompatibilityTest {
+class CompatibilityTest {
 
-    @After
-    public void restoreCompatibilityState() {
+    @AfterEach
+    void restoreCompatibilityState() {
         try {
             for (String fieldName : asList("supportsContextualType", "supportsTypeId")) {
                 Field field = Compatibility.class.getDeclaredField(fieldName);
@@ -57,45 +54,45 @@ public class CompatibilityTest {
     }
 
     @Test
-    public void testGetContextualType() {
+    void testGetContextualType() {
         DeserializationContext ctx = mock(DeserializationContext.class);
         JavaType javaType = mock(JavaType.class);
         when(ctx.getContextualType()).thenReturn(javaType);
 
-        assertThat(Compatibility.getContextualType(ctx), is(equalTo(javaType)));
+        assertThat(Compatibility.getContextualType(ctx)).isEqualTo(javaType);
 
         verify(ctx).getContextualType();
         verifyNoMoreInteractions(ctx, javaType);
     }
 
     @Test
-    public void testGetContextualType_NoSuchMethodError() {
+    void testGetContextualType_NoSuchMethodError() {
         DeserializationContext ctx = mock(DeserializationContext.class);
         when(ctx.getContextualType()).thenThrow(new NoSuchMethodError("DeserializationContext.getContextualType()"));
 
-        assertThat(Compatibility.getContextualType(ctx), is(nullValue())); // No error, but <null> result.
+        assertThat(Compatibility.getContextualType(ctx)).isNull(); // No error, but <null> result.
 
         verify(ctx).getContextualType();
         verifyNoMoreInteractions(ctx);
     }
 
     @Test
-    public void testGetTypeId() throws IOException {
+    void testGetTypeId() throws IOException {
         JsonParser parser = mock(JsonParser.class);
         when(parser.getTypeId()).thenReturn(BigCo.class);
 
-        assertThat(Compatibility.getTypeId(parser), is(equalTo((Object) BigCo.class)));
+        assertThat(Compatibility.getTypeId(parser)).isEqualTo(BigCo.class);
 
         verify(parser).getTypeId();
         verifyNoMoreInteractions(parser);
     }
 
     @Test
-    public void testGetTypeId_NoSuchMethodError() throws IOException {
+    void testGetTypeId_NoSuchMethodError() throws IOException {
         JsonParser parser = mock(JsonParser.class);
         when(parser.getTypeId()).thenThrow(NoSuchMethodError.class);
 
-        assertThat(Compatibility.getTypeId(parser), is(nullValue()));
+        assertThat(Compatibility.getTypeId(parser)).isNull();
 
         verify(parser).getTypeId();
         verifyNoMoreInteractions(parser);

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModuleTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModuleTest.java
@@ -46,7 +46,7 @@ class EnumerableModuleTest {
     ObjectMapper mapper, mapperAsObject, mapperWithException;
     EnumerableModule module;
 
-    private final ThreadLocal<Locale> defaultLocale = new ThreadLocal<Locale>();
+    private final ThreadLocal<Locale> defaultLocale = new ThreadLocal<>();
 
     @BeforeEach
     void setUpLocale() {
@@ -121,14 +121,14 @@ class EnumerableModuleTest {
         actual = mapperAsObject.writeValueAsString(testObject);
         JSONAssert.assertEquals(expected, actual, true);
 
-        // Serialization as exception to object (i.e. String again)
+        // Serialization as exception to object (i.e., String again)
         expected = "{ \"bigCo\" : \"Microsoft\" }";
         actual = mapperWithException.writeValueAsString(testObject);
         JSONAssert.assertEquals(expected, actual, true);
     }
 
     @Test
-    void testDeserialize_nullString() throws IOException {
+    void testDeserialize_nullString() {
         assertThatThrownBy(() -> mapper.readValue((String) null, BigCo.class))
                 .isInstanceOfAny(NullPointerException.class, IllegalArgumentException.class);
     }
@@ -177,14 +177,14 @@ class EnumerableModuleTest {
     }
 
     @Test
-    void testDeserialize_objectRepresentation_emptyObject() throws IOException {
+    void testDeserialize_objectRepresentation_emptyObject() {
         String json = "{ \"bigCo\" : { } }";
         assertThatThrownBy(() -> mapper.readValue(json, PlainTestObject.class))
                 .isInstanceOf(JsonMappingException.class);
     }
 
     @Test
-    void testDeserialize_unknownObjectRepresentation() throws IOException {
+    void testDeserialize_unknownObjectRepresentation() {
         String json = "{ \"bigCo\" : { \"val\" : \"IBM\" } }";
         assertThatThrownBy(() -> mapper.readValue(json, PlainTestObject.class))
                 .isInstanceOf(JsonMappingException.class);
@@ -209,7 +209,7 @@ class EnumerableModuleTest {
 
     @Test
     void testHashcode_equals() {
-        Set<EnumerableModule> set = new HashSet<EnumerableModule>();
+        Set<EnumerableModule> set = new HashSet<>();
         assertThat(set.add(module)).isTrue();
         assertThat(set.add(module)).isFalse();
         assertThat(set.add(new EnumerableModule(AS_STRING))).isFalse();

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModuleTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import nl.talsmasoftware.enumerables.Enumerable;
 import nl.talsmasoftware.enumerables.jackson2.PlainTestObject.BigCo;
-import org.hamcrest.MatcherAssert;
 import org.json.JSONException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
@@ -39,32 +38,24 @@ import java.util.Set;
 import static nl.talsmasoftware.enumerables.jackson2.EnumerableDeserializerTest.jsonString;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_OBJECT;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_STRING;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class EnumerableModuleTest {
+class EnumerableModuleTest {
 
     ObjectMapper mapper, mapperAsObject, mapperWithException;
     EnumerableModule module;
 
     private final ThreadLocal<Locale> defaultLocale = new ThreadLocal<Locale>();
 
-    @Before
-    public void setUpLocale() {
+    @BeforeEach
+    void setUpLocale() {
         defaultLocale.set(Locale.getDefault());
         Locale.setDefault(Locale.UK);
     }
 
-    @After
-    public void restoreLocale() {
+    @AfterEach
+    void restoreLocale() {
         Locale.setDefault(defaultLocale.get());
         defaultLocale.remove();
     }
@@ -76,8 +67,8 @@ public class EnumerableModuleTest {
         return mapper;
     }
 
-    @Before
-    public void setUpMappers() {
+    @BeforeEach
+    void setUpMappers() {
         module = new EnumerableModule();
         mapper = createMapper().registerModule(module);
         mapperAsObject = createMapper().registerModule(new EnumerableModule(AS_OBJECT));
@@ -85,26 +76,26 @@ public class EnumerableModuleTest {
     }
 
     @Test
-    public void testSerialize_null() throws IOException {
-        assertThat(mapper.writeValueAsString(null), is(equalTo("null")));
+    void testSerialize_null() throws IOException {
+        assertThat(mapper.writeValueAsString(null)).isEqualTo("null");
     }
 
     @Test
-    public void testSerialize_emptyString() throws IOException {
-        assertThat(mapper.writeValueAsString(Enumerable.parse(BigCo.class, "")), is(equalTo(jsonString(""))));
+    void testSerialize_emptyString() throws IOException {
+        assertThat(mapper.writeValueAsString(Enumerable.parse(BigCo.class, ""))).isEqualTo(jsonString(""));
     }
 
     @Test
-    public void testSerialize_stringValue() throws IOException {
+    void testSerialize_stringValue() throws IOException {
         for (BigCo bigCo : Enumerable.values(BigCo.class)) {
-            assertThat(mapper.writeValueAsString(bigCo), is(equalTo(jsonString(bigCo.getValue()))));
+            assertThat(mapper.writeValueAsString(bigCo)).isEqualTo(jsonString(bigCo.getValue()));
         }
-        assertThat(mapper.writeValueAsString(Enumerable.parse(BigCo.class, "VMWare")),
-                is(equalTo(jsonString("VMWare"))));
+        assertThat(mapper.writeValueAsString(Enumerable.parse(BigCo.class, "VMWare")))
+                .isEqualTo(jsonString("VMWare"));
     }
 
     @Test
-    public void testSerialize_asObject() throws IOException, JSONException {
+    void testSerialize_asObject() throws IOException, JSONException {
         for (BigCo bigCo : Enumerable.values(BigCo.class)) {
             String expected = String.format("{ \"value\" : \"%s\" }", bigCo.getValue());
             String actual = mapperAsObject.writeValueAsString(bigCo);
@@ -116,7 +107,7 @@ public class EnumerableModuleTest {
     }
 
     @Test
-    public void testSerialize_usingContainerObject() throws IOException, JSONException {
+    void testSerialize_usingContainerObject() throws IOException, JSONException {
         PlainTestObject testObject = new PlainTestObject();
         testObject.setBigCo(BigCo.MICROSOFT);
 
@@ -137,80 +128,75 @@ public class EnumerableModuleTest {
     }
 
     @Test
-    public void testDeserialize_nullString() throws IOException {
-        try {
-            mapper.readValue((String) null, BigCo.class);
-            throw new AssertionError("Exception expected");
-        } catch (RuntimeException expected) {
-            assertThat(expected, anyOf(
-                    instanceOf(NullPointerException.class),
-                    instanceOf(IllegalArgumentException.class)));
-        }
+    void testDeserialize_nullString() throws IOException {
+        assertThatThrownBy(() -> mapper.readValue((String) null, BigCo.class))
+                .isInstanceOfAny(NullPointerException.class, IllegalArgumentException.class);
     }
 
     @Test
-    public void testDeserialize_jsonNullValue() throws IOException {
-        assertThat(mapper.readValue("null", BigCo.class), nullValue());
+    void testDeserialize_jsonNullValue() throws IOException {
+        assertThat(mapper.readValue("null", BigCo.class)).isNull();
     }
 
     @Test
-    public void testDeserialize_emptyString() throws IOException {
+    void testDeserialize_emptyString() throws IOException {
         BigCo emptyBigCo = mapper.readValue("\"\"", BigCo.class);
-        MatcherAssert.assertThat(emptyBigCo, notNullValue());
-        MatcherAssert.assertThat(emptyBigCo.getValue(), is(equalTo("")));
-        MatcherAssert.assertThat(emptyBigCo.toString(), is(equalTo("BigCo{value=}")));
+        assertThat(emptyBigCo).isNotNull().hasToString("BigCo{value=}");
+        assertThat(emptyBigCo.getValue()).isEmpty();
     }
 
     @Test
-    public void testDeserialize_StringValue() throws IOException {
+    void testDeserialize_StringValue() throws IOException {
         for (BigCo bigCo : Enumerable.values(BigCo.class)) {
             BigCo actual = mapper.readValue(jsonString(bigCo.getValue()), BigCo.class);
-            assertThat(actual, is(sameInstance(bigCo)));
+            assertThat(actual).isSameAs(bigCo);
         }
-        assertThat(mapper.readValue(jsonString("VMWare"), BigCo.class),
-                is(equalTo(Enumerable.parse(BigCo.class, "VMWare"))));
+        assertThat(mapper.readValue(jsonString("VMWare"), BigCo.class))
+                .isEqualTo(Enumerable.parse(BigCo.class, "VMWare"));
     }
 
     @Test
-    public void testDeserialize_wrapperObject() throws IOException {
+    void testDeserialize_wrapperObject() throws IOException {
         String json = "{ \"bigCo\" : \"Microsoft\" }";
         PlainTestObject actual = mapper.readValue(json, PlainTestObject.class);
-        assertThat(actual, is(equalTo(new PlainTestObject(BigCo.MICROSOFT))));
-        assertThat(actual.getBigCo(), is(sameInstance(BigCo.MICROSOFT)));
+        assertThat(actual).isEqualTo(new PlainTestObject(BigCo.MICROSOFT));
+        assertThat(actual.getBigCo()).isSameAs(BigCo.MICROSOFT);
 
         actual = mapperAsObject.readValue(json, PlainTestObject.class);
-        assertThat(actual, is(equalTo(new PlainTestObject(BigCo.MICROSOFT))));
-        assertThat(actual.getBigCo(), is(sameInstance(BigCo.MICROSOFT)));
+        assertThat(actual).isEqualTo(new PlainTestObject(BigCo.MICROSOFT));
+        assertThat(actual.getBigCo()).isSameAs(BigCo.MICROSOFT);
     }
 
     @Test
-    public void testDeserialize_objectRepresentation() throws IOException {
+    void testDeserialize_objectRepresentation() throws IOException {
         String json = "{ \"bigCo\" : { \"value\" : \"IBM\" } }";
         PlainTestObject actual = mapper.readValue(json, PlainTestObject.class);
 
-        assertThat(actual, is(equalTo(new PlainTestObject(BigCo.IBM))));
-        assertThat(actual.getBigCo(), is(sameInstance(BigCo.IBM)));
+        assertThat(actual).isEqualTo(new PlainTestObject(BigCo.IBM));
+        assertThat(actual.getBigCo()).isSameAs(BigCo.IBM);
     }
 
-    @Test(expected = JsonMappingException.class)
-    public void testDeserialize_objectRepresentation_emptyObject() throws IOException {
+    @Test
+    void testDeserialize_objectRepresentation_emptyObject() throws IOException {
         String json = "{ \"bigCo\" : { } }";
-        mapper.readValue(json, PlainTestObject.class);
+        assertThatThrownBy(() -> mapper.readValue(json, PlainTestObject.class))
+                .isInstanceOf(JsonMappingException.class);
     }
 
-    @Test(expected = JsonMappingException.class)
-    public void testDeserialize_unknownObjectRepresentation() throws IOException {
+    @Test
+    void testDeserialize_unknownObjectRepresentation() throws IOException {
         String json = "{ \"bigCo\" : { \"val\" : \"IBM\" } }";
-        mapper.readValue(json, PlainTestObject.class);
+        assertThatThrownBy(() -> mapper.readValue(json, PlainTestObject.class))
+                .isInstanceOf(JsonMappingException.class);
     }
 
     @Test
-    public void testToString() {
-        assertThat(module, hasToString("EnumerableModule"));
+    void testToString() {
+        assertThat(module).hasToString("EnumerableModule");
     }
 
     @Test
-    public void testDeserialize_wrapperObjectFrom_treeAsTokens() throws IOException {
+    void testDeserialize_wrapperObjectFrom_treeAsTokens() throws IOException {
         String json = "{ \"bigCo\" : \"Microsoft\" }";
 
         final MappingJsonFactory jsonFactory = new MappingJsonFactory(mapper);
@@ -218,17 +204,17 @@ public class EnumerableModuleTest {
 
         ObjectNode objectNode = mapper.readTree(jp);
         PlainTestObject actual = mapper.readValue(mapper.treeAsTokens(objectNode), PlainTestObject.class);
-        assertThat(actual, is(equalTo(new PlainTestObject(BigCo.MICROSOFT))));
+        assertThat(actual).isEqualTo(new PlainTestObject(BigCo.MICROSOFT));
     }
 
     @Test
-    public void testHashcode_equals() {
+    void testHashcode_equals() {
         Set<EnumerableModule> set = new HashSet<EnumerableModule>();
-        assertThat(set.add(module), is(true));
-        assertThat(set.add(module), is(false));
-        assertThat(set.add(new EnumerableModule(AS_STRING)), is(false));
-        assertThat(set.add(new EnumerableModule(AS_OBJECT)), is(false));
-        assertThat(set.add(new EnumerableModule(AS_STRING.except(BigCo.class))), is(false));
-        assertThat(set, hasSize(1));
+        assertThat(set.add(module)).isTrue();
+        assertThat(set.add(module)).isFalse();
+        assertThat(set.add(new EnumerableModule(AS_STRING))).isFalse();
+        assertThat(set.add(new EnumerableModule(AS_OBJECT))).isFalse();
+        assertThat(set.add(new EnumerableModule(AS_STRING.except(BigCo.class)))).isFalse();
+        assertThat(set).hasSize(1);
     }
 }

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableSerializerTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/EnumerableSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import nl.talsmasoftware.enumerables.Enumerable;
 import nl.talsmasoftware.enumerables.jackson2.PlainTestObject.BigCo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -30,17 +30,14 @@ import static com.fasterxml.jackson.core.Version.unknownVersion;
 import static nl.talsmasoftware.enumerables.jackson2.EnumerableDeserializerTest.jsonString;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_OBJECT;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_STRING;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnumerableSerializerTest {
+class EnumerableSerializerTest {
 
     ObjectMapper mapper;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         SimpleModule bigCoModule = new SimpleModule("BigCo module", unknownVersion());
@@ -49,28 +46,28 @@ public class EnumerableSerializerTest {
     }
 
     @Test
-    public void testSerialize_null() throws IOException {
-        assertThat(mapper.writeValueAsString(null), is(equalTo("null")));
+    void testSerialize_null() throws IOException {
+        assertThat(mapper.writeValueAsString(null)).isEqualTo("null");
     }
 
     @Test
-    public void testSerialize_emptyString() throws IOException {
-        assertThat(mapper.writeValueAsString(Enumerable.parse(BigCo.class, "")), is(equalTo(jsonString(""))));
+    void testSerialize_emptyString() throws IOException {
+        assertThat(mapper.writeValueAsString(Enumerable.parse(BigCo.class, ""))).isEqualTo(jsonString(""));
     }
 
     @Test
-    public void testSerialize_stringValue() throws IOException {
+    void testSerialize_stringValue() throws IOException {
         for (BigCo bigCo : Enumerable.values(BigCo.class)) {
             String expected = jsonString(bigCo.getValue());
             String actual = mapper.writeValueAsString(bigCo);
-            assertThat(actual, is(equalTo(expected)));
+            assertThat(actual).isEqualTo(expected);
         }
         String actual = mapper.writeValueAsString(Enumerable.parse(BigCo.class, "VMWare"));
-        assertThat(actual, is(equalTo(jsonString("VMWare"))));
+        assertThat(actual).isEqualTo(jsonString("VMWare"));
     }
 
     @Test
-    public void testSerialize_jsonObject() throws IOException {
+    void testSerialize_jsonObject() throws IOException {
         mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         SimpleModule bigCoModule = new SimpleModule("BigCo module", unknownVersion());
@@ -80,37 +77,35 @@ public class EnumerableSerializerTest {
         for (BigCo bigCo : Enumerable.values(BigCo.class)) {
             String expected = "{\"value\":" + jsonString(bigCo.getValue()) + "}";
             String actual = mapper.writeValueAsString(bigCo);
-            assertThat(actual, is(equalTo(expected)));
+            assertThat(actual).isEqualTo(expected);
         }
         String expected = "{\"value\":" + jsonString("VMWare") + "}";
         String actual = mapper.writeValueAsString(Enumerable.parse(BigCo.class, "VMWare"));
-        assertThat(actual, is(equalTo(expected)));
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void testSerialize_jsonWithAdditionalField() throws JsonProcessingException {
+    void testSerialize_jsonWithAdditionalField() throws JsonProcessingException {
         mapper.registerModule(new SimpleModule().addSerializer(Enumerable.class, new EnumerableSerializer(AS_OBJECT)));
 
-        assertThat(mapper.writeValueAsString(Numbers.ONE),
-                is("{\"value\":\"ONE\",\"number\":1}"));
-        assertThat(mapper.writeValueAsString(Numbers.TWO),
-                is("{\"value\":\"TWO\",\"number\":2}"));
-        assertThat(mapper.writeValueAsString(Enumerable.parse(Numbers.class, "THIRTEEN")),
-                is("{\"value\":\"THIRTEEN\"}"));
+        assertThat(mapper.writeValueAsString(Numbers.ONE))
+                .isEqualTo("{\"value\":\"ONE\",\"number\":1}");
+        assertThat(mapper.writeValueAsString(Numbers.TWO))
+                .isEqualTo("{\"value\":\"TWO\",\"number\":2}");
+        assertThat(mapper.writeValueAsString(Enumerable.parse(Numbers.class, "THIRTEEN")))
+                .isEqualTo("{\"value\":\"THIRTEEN\"}");
 
         mapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
-        assertThat(mapper.writeValueAsString(Enumerable.parse(Numbers.class, "THIRTEEN")),
-                is("{\"value\":\"THIRTEEN\",\"number\":null}"));
+        assertThat(mapper.writeValueAsString(Enumerable.parse(Numbers.class, "THIRTEEN")))
+                .isEqualTo("{\"value\":\"THIRTEEN\",\"number\":null}");
     }
 
     @Test
-    public void testToString() {
-        assertThat(new EnumerableSerializer(AS_OBJECT),
-                hasToString("EnumerableSerializer{As object}"));
-        assertThat(new EnumerableSerializer(AS_STRING),
-                hasToString("EnumerableSerializer{As string}"));
-        assertThat(new EnumerableSerializer(AS_OBJECT.except(BigCo.class)),
-                hasToString("EnumerableSerializer{As object, except [PlainTestObject$BigCo]}"));
+    void testToString() {
+        assertThat(new EnumerableSerializer(AS_OBJECT)).hasToString("EnumerableSerializer{As object}");
+        assertThat(new EnumerableSerializer(AS_STRING)).hasToString("EnumerableSerializer{As string}");
+        assertThat(new EnumerableSerializer(AS_OBJECT.except(BigCo.class)))
+                .hasToString("EnumerableSerializer{As object, except [PlainTestObject$BigCo]}");
     }
 
 }

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/SerializationMethodTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/SerializationMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,143 +16,138 @@
 package nl.talsmasoftware.enumerables.jackson2;
 
 import nl.talsmasoftware.enumerables.Enumerable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_OBJECT;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_STRING;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class SerializationMethodTest {
+class SerializationMethodTest {
 
     @Test
-    public void testIsObjectSerializationByDefault() {
-        assertThat(AS_STRING.isObjectSerializationByDefault(), is(false));
-        assertThat(AS_OBJECT.isObjectSerializationByDefault(), is(true));
+    void testIsObjectSerializationByDefault() {
+        assertThat(AS_STRING.isObjectSerializationByDefault()).isFalse();
+        assertThat(AS_OBJECT.isObjectSerializationByDefault()).isTrue();
     }
 
     @Test
-    public void testStandardBehaviour() {
-        assertThat(AS_STRING.serializeAsObject(Enumerable1.class), is(false));
-        assertThat(AS_STRING.serializeAsObject(Enumerable2.class), is(false));
-        assertThat(AS_STRING.serializeAsObject(Enumerable3.class), is(false));
+    void testStandardBehaviour() {
+        assertThat(AS_STRING.serializeAsObject(Enumerable1.class)).isFalse();
+        assertThat(AS_STRING.serializeAsObject(Enumerable2.class)).isFalse();
+        assertThat(AS_STRING.serializeAsObject(Enumerable3.class)).isFalse();
 
-        assertThat(AS_OBJECT.serializeAsObject(Enumerable1.class), is(true));
-        assertThat(AS_OBJECT.serializeAsObject(Enumerable2.class), is(true));
-        assertThat(AS_OBJECT.serializeAsObject(Enumerable3.class), is(true));
+        assertThat(AS_OBJECT.serializeAsObject(Enumerable1.class)).isTrue();
+        assertThat(AS_OBJECT.serializeAsObject(Enumerable2.class)).isTrue();
+        assertThat(AS_OBJECT.serializeAsObject(Enumerable3.class)).isTrue();
     }
 
     @Test
-    public void testSerializeAsObjectNull() {
-        assertThat(AS_STRING.serializeAsObject(null), is(false));
-        assertThat(AS_OBJECT.serializeAsObject(null), is(true));
+    void testSerializeAsObjectNull() {
+        assertThat(AS_STRING.serializeAsObject(null)).isFalse();
+        assertThat(AS_OBJECT.serializeAsObject(null)).isTrue();
     }
 
     @Test
     @SuppressWarnings({"unchecked", "deprecation"})
-    public void testAsStringExceptBehaviour() {
+    void testAsStringExceptBehaviour() {
         SerializationMethod serializationMethod = AS_STRING;
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(false));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isFalse();
 
         serializationMethod = AS_STRING.except(Enumerable3.class);
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(true));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isTrue();
 
         serializationMethod = AS_STRING.except(Enumerable2.class, Enumerable3.class);
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(true));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isTrue();
 
         serializationMethod = AS_STRING.except(Enumerable1.class, Enumerable2.class, Enumerable3.class);
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Numbers.class), is(false));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Numbers.class)).isFalse();
     }
 
     @Test
     @SuppressWarnings({"unchecked", "deprecation"})
-    public void testAsObjectExceptBehaviour() {
+    void testAsObjectExceptBehaviour() {
         SerializationMethod serializationMethod = AS_OBJECT;
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(true));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isTrue();
 
         serializationMethod = AS_OBJECT.except(Enumerable3.class);
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(false));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isFalse();
 
         serializationMethod = AS_OBJECT.except(Enumerable2.class, Enumerable3.class);
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(true));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(false));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isTrue();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isFalse();
 
         serializationMethod = AS_OBJECT.except(Enumerable1.class, Enumerable2.class, Enumerable3.class);
-        assertThat(serializationMethod.serializeAsObject(Enumerable1.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable2.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Enumerable3.class), is(false));
-        assertThat(serializationMethod.serializeAsObject(Numbers.class), is(true));
+        assertThat(serializationMethod.serializeAsObject(Enumerable1.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable2.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Enumerable3.class)).isFalse();
+        assertThat(serializationMethod.serializeAsObject(Numbers.class)).isTrue();
     }
 
     @Test
-    public void testExceptNull() {
-        assertThat(AS_STRING.except((Class<? extends Enumerable>) null), is(sameInstance(AS_STRING)));
+    void testExceptNull() {
+        assertThat(AS_STRING.except((Class<? extends Enumerable>) null)).isSameAs(AS_STRING);
     }
 
     @Test
-    public void testHashCode() {
-        assertThat(AS_STRING.hashCode(), is(AS_STRING.hashCode()));
-        assertThat(AS_STRING.hashCode(), is(not(AS_OBJECT.hashCode()))); // Stronger than hashcode contract
-        assertThat(AS_STRING.hashCode(), is(AS_STRING.except((Class<? extends Enumerable>) null).hashCode()));
+    void testHashCode() {
+        assertThat(AS_STRING).hasSameHashCodeAs(AS_STRING);
+        assertThat(AS_STRING).doesNotHaveSameHashCodeAs(AS_OBJECT); // Stronger than hashcode contract
+        assertThat(AS_STRING).hasSameHashCodeAs(AS_STRING.except((Class<? extends Enumerable>) null));
 
-        assertThat(AS_OBJECT.except(Enumerable2.class).hashCode(), is(AS_OBJECT.except(Enumerable2.class).hashCode()));
+        assertThat(AS_OBJECT.except(Enumerable2.class)).hasSameHashCodeAs(AS_OBJECT.except(Enumerable2.class));
     }
 
     @Test
-    public void testEquals() {
-        assertThat(AS_STRING, is(equalTo(AS_STRING)));
-        assertThat(AS_STRING, is(not(equalTo(AS_STRING.except(Enumerable1.class)))));
-        assertThat(AS_STRING, is(not(equalTo(AS_OBJECT))));
+    void testEquals() {
+        assertThat(AS_STRING).isEqualTo(AS_STRING);
+        assertThat(AS_STRING).isNotEqualTo(AS_STRING.except(Enumerable1.class));
+        assertThat(AS_STRING).isNotEqualTo(AS_OBJECT);
 
-        assertThat(AS_OBJECT.except(Enumerable2.class), is(equalTo(AS_OBJECT.except(Enumerable2.class))));
+        assertThat(AS_OBJECT.except(Enumerable2.class)).isEqualTo(AS_OBJECT.except(Enumerable2.class));
     }
 
     @Test
-    public void testToString() {
-        assertThat(AS_STRING, hasToString("As string"));
-        assertThat(AS_OBJECT, hasToString("As object"));
-        assertThat(AS_STRING.except(Enumerable3.class),
-                hasToString("As string, except [SerializationMethodTest$Enumerable3]"));
-        assertThat(AS_OBJECT.except(asList(Enumerable1.class, Enumerable3.class)), hasToString(
-                "As object, except [SerializationMethodTest$Enumerable1, SerializationMethodTest$Enumerable3]"));
+    void testToString() {
+        assertThat(AS_STRING).hasToString("As string");
+        assertThat(AS_OBJECT).hasToString("As object");
+        assertThat(AS_STRING.except(Enumerable3.class))
+                .hasToString("As string, except [SerializationMethodTest$Enumerable3]");
+        assertThat(AS_OBJECT.except(asList(Enumerable1.class, Enumerable3.class))).hasToString(
+                "As object, except [SerializationMethodTest$Enumerable1, SerializationMethodTest$Enumerable3]");
     }
 
-    private static final class Enumerable1 extends Enumerable {
-        private Enumerable1(String value) {
+    static final class Enumerable1 extends Enumerable {
+        Enumerable1(String value) {
             super(value);
         }
     }
 
-    private static final class Enumerable2 extends Enumerable {
-        private Enumerable2(String value) {
+    static final class Enumerable2 extends Enumerable {
+        Enumerable2(String value) {
             super(value);
         }
     }
 
-    private static final class Enumerable3 extends Enumerable {
-        private Enumerable3(String value) {
+    static final class Enumerable3 extends Enumerable {
+        Enumerable3(String value) {
             super(value);
         }
     }

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/SerializationMethodTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/SerializationMethodTest.java
@@ -108,18 +108,20 @@ class SerializationMethodTest {
 
     @Test
     void testHashCode() {
-        assertThat(AS_STRING).hasSameHashCodeAs(AS_STRING);
-        assertThat(AS_STRING).doesNotHaveSameHashCodeAs(AS_OBJECT); // Stronger than hashcode contract
-        assertThat(AS_STRING).hasSameHashCodeAs(AS_STRING.except((Class<? extends Enumerable>) null));
+        assertThat(AS_STRING)
+                .hasSameHashCodeAs(AS_STRING)
+                .doesNotHaveSameHashCodeAs(AS_OBJECT) // Stronger than hashcode contract
+                .hasSameHashCodeAs(AS_STRING.except((Class<? extends Enumerable>) null));
 
         assertThat(AS_OBJECT.except(Enumerable2.class)).hasSameHashCodeAs(AS_OBJECT.except(Enumerable2.class));
     }
 
     @Test
     void testEquals() {
-        assertThat(AS_STRING).isEqualTo(AS_STRING);
-        assertThat(AS_STRING).isNotEqualTo(AS_STRING.except(Enumerable1.class));
-        assertThat(AS_STRING).isNotEqualTo(AS_OBJECT);
+        assertThat(AS_STRING)
+                .isEqualTo(AS_STRING)
+                .isNotEqualTo(AS_STRING.except(Enumerable1.class))
+                .isNotEqualTo(AS_OBJECT);
 
         assertThat(AS_OBJECT.except(Enumerable2.class)).isEqualTo(AS_OBJECT.except(Enumerable2.class));
     }

--- a/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/bug25/DeserializationEqualityTest.java
+++ b/enumerables-jackson2/src/test/java/nl/talsmasoftware/enumerables/jackson2/bug25/DeserializationEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,37 +18,36 @@ package nl.talsmasoftware.enumerables.jackson2.bug25;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.talsmasoftware.enumerables.jackson2.EnumerableModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static java.util.Arrays.asList;
 import static nl.talsmasoftware.enumerables.jackson2.SerializationMethod.AS_STRING;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by kroon.r on 28-06-2017.
  */
-public class DeserializationEqualityTest {
+class DeserializationEqualityTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(new EnumerableModule(AS_STRING));
 
     @Test
-    public void testAsList() throws IOException {
+    void testAsList() throws IOException {
         TypeWithEnumerableList original = new TypeWithEnumerableList();
         original.stringValue = "A String value";
         original.teammembers = asList(Team.RICHARD);
         String asString = MAPPER.writeValueAsString(original);
 
         TypeWithEnumerableList deserialized = MAPPER.readValue(asString, TypeWithEnumerableList.class);
-        assertThat("deserialized representation", deserialized, equalTo(original));
+        assertThat(deserialized).as("Deserialized representation").isEqualTo(original);
     }
 
     @Test
-    public void testAsWrappedList() throws IOException {
+    void testAsWrappedList() throws IOException {
         TypeWithListContainingNestedEnumerable original = new TypeWithListContainingNestedEnumerable();
         original.stringValue = "A String value";
 
@@ -61,7 +60,7 @@ public class DeserializationEqualityTest {
         String asString = MAPPER.writeValueAsString(original);
 
         TypeWithListContainingNestedEnumerable deserialized = MAPPER.readValue(asString, TypeWithListContainingNestedEnumerable.class);
-        assertThat("deserialized representation", deserialized, equalTo(original));
+        assertThat(deserialized).as("Deserialized representation").isEqualTo(original);
     }
 
 }

--- a/enumerables-jakarta-validation/src/test/java/nl/talsmasoftware/enumerables/jakarta/validation/IsOneOfCharSequenceValidatorTest.java
+++ b/enumerables-jakarta-validation/src/test/java/nl/talsmasoftware/enumerables/jakarta/validation/IsOneOfCharSequenceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,28 +20,22 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import nl.talsmasoftware.enumerables.jakarta.validation.constraints.IsOneOf;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 import java.util.Set;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class IsOneOfCharSequenceValidatorTest {
+class IsOneOfCharSequenceValidatorTest {
 
     static class ValidatedObject {
         @IsOneOf({"Ferrari", "Aston martin"})
@@ -56,18 +50,18 @@ public class IsOneOfCharSequenceValidatorTest {
     Validator validator;
     Set<ConstraintViolation<ValidatedObject>> violations;
 
-    @BeforeClass
-    public static void rememberOldDefaultLocale() {
+    @BeforeAll
+    static void rememberOldDefaultLocale() {
         if (oldDefaultLocale == null) oldDefaultLocale = Locale.getDefault();
     }
 
-    @AfterClass
-    public static void restoreOldDefaultLocale() {
+    @AfterAll
+    static void restoreOldDefaultLocale() {
         Locale.setDefault(oldDefaultLocale);
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
         validator = Validation.byDefaultProvider()
@@ -78,38 +72,38 @@ public class IsOneOfCharSequenceValidatorTest {
     }
 
     @Test
-    public void testIsOneOfCharSeq_charsequence_null() {
+    void testIsOneOfCharSeq_charsequence_null() {
         violations = validator.validate(new ValidatedObject(null));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOfCharSeq_validString() {
+    void testIsOneOfCharSeq_validString() {
         violations = validator.validate(new ValidatedObject("Ferrari"));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOfCharSeq_otherString() {
+    void testIsOneOfCharSeq_otherString() {
         violations = validator.validate(new ValidatedObject("Lamborghini"));
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getPropertyPath(), hasToString("brand"));
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
-    public void testIsOneOfCharSeq_ValidationMessage_i18n() {
+    void testIsOneOfCharSeq_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator.validate(new ValidatedObject("Lamborghini")).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
 
         ClientLocaleHolder.set(ClientLocaleHolder.DUTCH);
         violation = validator.validate(new ValidatedObject("Lamborghini")).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is niet een waarde uit [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is niet een waarde uit [Ferrari, Aston martin]");
 
         // Does fallback to default work as expected?
         ClientLocaleHolder.set(ClientLocaleHolder.FRISIAN);
         violation = validator.validate(new ValidatedObject("Lamborghini")).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
     }
 
 }

--- a/enumerables-jakarta-validation/src/test/java/nl/talsmasoftware/enumerables/jakarta/validation/IsOneOfEnumerablesValidatorTest.java
+++ b/enumerables-jakarta-validation/src/test/java/nl/talsmasoftware/enumerables/jakarta/validation/IsOneOfEnumerablesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,29 +21,23 @@ import jakarta.validation.Validator;
 import nl.talsmasoftware.enumerables.Enumerable;
 import nl.talsmasoftware.enumerables.jakarta.validation.constraints.IsOneOf;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 import java.util.Set;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
  * @author Sjoerd Talsma
  */
-public class IsOneOfEnumerablesValidatorTest {
+class IsOneOfEnumerablesValidatorTest {
 
     static class ValidatedObject {
         @IsOneOf({"Ferrari", "Aston martin"})
@@ -65,18 +59,18 @@ public class IsOneOfEnumerablesValidatorTest {
     Validator validator;
     Set<ConstraintViolation<ValidatedObject>> violations;
 
-    @BeforeClass
-    public static void rememberOldDefaultLocale() {
+    @BeforeAll
+    static void rememberOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.rememberOldDefaultLocale();
     }
 
-    @AfterClass
-    public static void restoreOldDefaultLocale() {
+    @AfterAll
+    static void restoreOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.restoreOldDefaultLocale();
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
         validator = Validation.byDefaultProvider()
@@ -87,51 +81,51 @@ public class IsOneOfEnumerablesValidatorTest {
     }
 
     @Test
-    public void testIsOneOf_enumerable_null() {
+    void testIsOneOf_enumerable_null() {
         violations = validator.validate(new ValidatedObject(null));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOf_validEnumerable() {
+    void testIsOneOf_validEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.FERRARI));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOf_otherEnumerable() {
+    void testIsOneOf_otherEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI));
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getPropertyPath(), hasToString("brand"));
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
-    public void testIsOneOf_caseInsensitive() {
+    void testIsOneOf_caseInsensitive() {
         CarBrand loweredFerrari = Enumerable.parse(CarBrand.class, "ferrari");
-        assertThat(loweredFerrari, is(not(equalTo(CarBrand.FERRARI))));
+        assertThat(loweredFerrari).isNotEqualTo(CarBrand.FERRARI);
 
         // Verify validationerror
         violations = validator.validate(new ValidatedObject(loweredFerrari));
-        assertThat(violations, hasSize(1));
+        assertThat(violations).hasSize(1);
 
         violations = validator.validate(new ValidatedObject(null, loweredFerrari));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOfCharSeq_ValidationMessage_i18n() {
+    void testIsOneOfCharSeq_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
 
         ClientLocaleHolder.set(ClientLocaleHolder.DUTCH);
         violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is niet een waarde uit [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is niet een waarde uit [Ferrari, Aston martin]");
 
         // Does fallback to default work as expected?
         ClientLocaleHolder.set(ClientLocaleHolder.FRISIAN);
         violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
     }
 
 }

--- a/enumerables-jakarta-validation/src/test/java/nl/talsmasoftware/enumerables/jakarta/validation/KnownValueValidatorTest.java
+++ b/enumerables-jakarta-validation/src/test/java/nl/talsmasoftware/enumerables/jakarta/validation/KnownValueValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import jakarta.validation.Validator;
 import jakarta.validation.constraints.NotNull;
 import nl.talsmasoftware.enumerables.jakarta.validation.constraints.KnownValue;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 import java.util.Set;
@@ -32,18 +32,12 @@ import java.util.Set;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.FRENCH;
 import static java.util.Locale.GERMAN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class KnownValueValidatorTest {
+class KnownValueValidatorTest {
 
     static class ValidatedObject {
         @KnownValue
@@ -62,18 +56,18 @@ public class KnownValueValidatorTest {
     Validator validator;
     Set<ConstraintViolation<ValidatedObject>> violations;
 
-    @BeforeClass
-    public static void rememberOldDefaultLocale() {
+    @BeforeAll
+    static void rememberOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.rememberOldDefaultLocale();
     }
 
-    @AfterClass
-    public static void restoreOldDefaultLocale() {
+    @AfterAll
+    static void restoreOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.restoreOldDefaultLocale();
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
         validator = Validation.byDefaultProvider()
@@ -84,52 +78,52 @@ public class KnownValueValidatorTest {
     }
 
     @Test
-    public void testKnownValue_enumerable_null() {
+    void testKnownValue_enumerable_null() {
         violations = validator.validate(new ValidatedObject(null));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testKnownValue_validEnumerable() {
+    void testKnownValue_validEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.FERRARI));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testKnownValue_otherEnumerable() {
+    void testKnownValue_otherEnumerable() {
         ClientLocaleHolder.set(ENGLISH);
         violations = validator.validate(new ValidatedObject(CarBrand.parseLeniently("Unknown brand")));
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getPropertyPath(), hasToString("brand"));
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
-    public void testKnownValue_ValidationMessage_i18n() {
+    void testKnownValue_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator
                 .validate(new ValidatedObject(CarBrand.parseLeniently("Unknown brand"))).iterator().next();
-        assertThat(violation.getMessage(), equalTo("not a known constant value"));
+        assertThat(violation.getMessage()).isEqualTo("not a known constant value");
 
         ClientLocaleHolder.set(ClientLocaleHolder.DUTCH);
         violation = validator.validate(new ValidatedObject(CarBrand.parseLeniently("Onbekend merk"))).iterator().next();
-        assertThat(violation.getMessage(), equalTo("geen bekende constante waarde"));
+        assertThat(violation.getMessage()).isEqualTo("geen bekende constante waarde");
 
         // Does fallback to default work as expected?
         ClientLocaleHolder.set(ClientLocaleHolder.FRISIAN);
         violation = validator.validate(new ValidatedObject(CarBrand.parseLeniently("Unknown brand"))).iterator().next();
-        assertThat(violation.getMessage(), equalTo("not a known constant value"));
+        assertThat(violation.getMessage()).isEqualTo("not a known constant value");
     }
 
     @Test
-    public void testStandardMessages_i18n() {
+    void testStandardMessages_i18n() {
         final String englishNonNullMessage = "must not be null";
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<StandardMessagesObject> violation = validator.validate(new StandardMessagesObject()).iterator().next();
-        assertThat(violation.getMessage(), equalTo(englishNonNullMessage));
+        assertThat(violation.getMessage()).isEqualTo(englishNonNullMessage);
 
         ClientLocaleHolder.set(FRENCH);
         violation = validator.validate(new StandardMessagesObject()).iterator().next();
-        assertThat(violation.getMessage(), not(equalTo(englishNonNullMessage)));
+        assertThat(violation.getMessage()).isNotEqualTo(englishNonNullMessage);
     }
 
 }

--- a/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/IsOneOfCharSequenceValidatorTest.java
+++ b/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/IsOneOfCharSequenceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 package nl.talsmasoftware.enumerables.validation;
 
 import nl.talsmasoftware.enumerables.constraints.IsOneOf;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
@@ -30,18 +30,12 @@ import java.util.Set;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class IsOneOfCharSequenceValidatorTest {
+class IsOneOfCharSequenceValidatorTest {
 
     static class ValidatedObject {
         @IsOneOf({"Ferrari", "Aston martin"})
@@ -56,18 +50,18 @@ public class IsOneOfCharSequenceValidatorTest {
     Validator validator;
     Set<ConstraintViolation<ValidatedObject>> violations;
 
-    @BeforeClass
-    public static void rememberOldDefaultLocale() {
+    @BeforeAll
+    static void rememberOldDefaultLocale() {
         if (oldDefaultLocale == null) oldDefaultLocale = Locale.getDefault();
     }
 
-    @AfterClass
-    public static void restoreOldDefaultLocale() {
+    @AfterAll
+    static void restoreOldDefaultLocale() {
         Locale.setDefault(oldDefaultLocale);
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
         Configuration config = Validation.byDefaultProvider().configure();
@@ -77,38 +71,38 @@ public class IsOneOfCharSequenceValidatorTest {
 
 
     @Test
-    public void testIsOneOfCharSeq_charsequence_null() {
+    void testIsOneOfCharSeq_charsequence_null() {
         violations = validator.validate(new ValidatedObject(null));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOfCharSeq_validString() {
+    void testIsOneOfCharSeq_validString() {
         violations = validator.validate(new ValidatedObject("Ferrari"));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOfCharSeq_otherString() {
+    void testIsOneOfCharSeq_otherString() {
         violations = validator.validate(new ValidatedObject("Lamborghini"));
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getPropertyPath(), hasToString("brand"));
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
-    public void testIsOneOfCharSeq_ValidationMessage_i18n() {
+    void testIsOneOfCharSeq_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator.validate(new ValidatedObject("Lamborghini")).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
 
         ClientLocaleHolder.set(ClientLocaleHolder.DUTCH);
         violation = validator.validate(new ValidatedObject("Lamborghini")).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is niet een waarde uit [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is niet een waarde uit [Ferrari, Aston martin]");
 
         // Does fallback to default work as expected?
         ClientLocaleHolder.set(ClientLocaleHolder.FRISIAN);
         violation = validator.validate(new ValidatedObject("Lamborghini")).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
     }
 
 }

--- a/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/IsOneOfEnumerablesValidatorTest.java
+++ b/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/IsOneOfEnumerablesValidatorTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Sjoerd Talsma
  */
-public class IsOneOfEnumerablesValidatorTest {
+class IsOneOfEnumerablesValidatorTest {
 
     static class ValidatedObject {
         @IsOneOf({"Ferrari", "Aston martin"})
@@ -60,17 +60,17 @@ public class IsOneOfEnumerablesValidatorTest {
     Set<ConstraintViolation<ValidatedObject>> violations;
 
     @BeforeAll
-    public static void rememberOldDefaultLocale() {
+    static void rememberOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.rememberOldDefaultLocale();
     }
 
     @AfterAll
-    public static void restoreOldDefaultLocale() {
+    static void restoreOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.restoreOldDefaultLocale();
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
         Configuration config = Validation.byDefaultProvider().configure();
@@ -79,26 +79,26 @@ public class IsOneOfEnumerablesValidatorTest {
     }
 
     @Test
-    public void testIsOneOf_enumerable_null() {
+    void testIsOneOf_enumerable_null() {
         violations = validator.validate(new ValidatedObject(null));
         assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOf_validEnumerable() {
+    void testIsOneOf_validEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.FERRARI));
         assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testIsOneOf_otherEnumerable() {
+    void testIsOneOf_otherEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI));
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
-    public void testIsOneOf_caseInsensitive() {
+    void testIsOneOf_caseInsensitive() {
         CarBrand loweredFerrari = Enumerable.parse(CarBrand.class, "ferrari");
         assertThat(loweredFerrari).isNotEqualTo(CarBrand.FERRARI);
 
@@ -111,7 +111,7 @@ public class IsOneOfEnumerablesValidatorTest {
     }
 
     @Test
-    public void testIsOneOfCharSeq_ValidationMessage_i18n() {
+    void testIsOneOfCharSeq_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
         assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");

--- a/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/IsOneOfEnumerablesValidatorTest.java
+++ b/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/IsOneOfEnumerablesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package nl.talsmasoftware.enumerables.validation;
 
 import nl.talsmasoftware.enumerables.Enumerable;
 import nl.talsmasoftware.enumerables.constraints.IsOneOf;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
@@ -31,13 +31,7 @@ import java.util.Set;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -65,17 +59,17 @@ public class IsOneOfEnumerablesValidatorTest {
     Validator validator;
     Set<ConstraintViolation<ValidatedObject>> violations;
 
-    @BeforeClass
+    @BeforeAll
     public static void rememberOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.rememberOldDefaultLocale();
     }
 
-    @AfterClass
+    @AfterAll
     public static void restoreOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.restoreOldDefaultLocale();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
@@ -87,49 +81,49 @@ public class IsOneOfEnumerablesValidatorTest {
     @Test
     public void testIsOneOf_enumerable_null() {
         violations = validator.validate(new ValidatedObject(null));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
     public void testIsOneOf_validEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.FERRARI));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
     public void testIsOneOf_otherEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI));
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getPropertyPath(), hasToString("brand"));
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
     public void testIsOneOf_caseInsensitive() {
         CarBrand loweredFerrari = Enumerable.parse(CarBrand.class, "ferrari");
-        assertThat(loweredFerrari, is(not(equalTo(CarBrand.FERRARI))));
+        assertThat(loweredFerrari).isNotEqualTo(CarBrand.FERRARI);
 
         // Verify validationerror
         violations = validator.validate(new ValidatedObject(loweredFerrari));
-        assertThat(violations, hasSize(1));
+        assertThat(violations).hasSize(1);
 
         violations = validator.validate(new ValidatedObject(null, loweredFerrari));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
     public void testIsOneOfCharSeq_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
 
         ClientLocaleHolder.set(ClientLocaleHolder.DUTCH);
         violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is niet een waarde uit [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is niet een waarde uit [Ferrari, Aston martin]");
 
         // Does fallback to default work as expected?
         ClientLocaleHolder.set(ClientLocaleHolder.FRISIAN);
         violation = validator.validate(new ValidatedObject(CarBrand.LAMBORGHINI)).iterator().next();
-        assertThat(violation.getMessage(), equalTo("is not one of [Ferrari, Aston martin]"));
+        assertThat(violation.getMessage()).isEqualTo("is not one of [Ferrari, Aston martin]");
     }
 
 }

--- a/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/KnownValueValidatorTest.java
+++ b/enumerables-javax-validation/src/test/java/nl/talsmasoftware/enumerables/validation/KnownValueValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 package nl.talsmasoftware.enumerables.validation;
 
 import nl.talsmasoftware.enumerables.constraints.KnownValue;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
@@ -32,18 +32,12 @@ import java.util.Set;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.FRENCH;
 import static java.util.Locale.GERMAN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class KnownValueValidatorTest {
+class KnownValueValidatorTest {
 
     static class ValidatedObject {
         @KnownValue
@@ -62,18 +56,18 @@ public class KnownValueValidatorTest {
     Validator validator;
     Set<ConstraintViolation<ValidatedObject>> violations;
 
-    @BeforeClass
-    public static void rememberOldDefaultLocale() {
+    @BeforeAll
+    static void rememberOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.rememberOldDefaultLocale();
     }
 
-    @AfterClass
-    public static void restoreOldDefaultLocale() {
+    @AfterAll
+    static void restoreOldDefaultLocale() {
         IsOneOfCharSequenceValidatorTest.restoreOldDefaultLocale();
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         Locale.setDefault(GERMAN); // Default to non-dutch or english to test.
         ClientLocaleHolder.set(ENGLISH);
         Configuration config = Validation.byDefaultProvider().configure();
@@ -82,52 +76,52 @@ public class KnownValueValidatorTest {
     }
 
     @Test
-    public void testKnownValue_enumerable_null() {
+    void testKnownValue_enumerable_null() {
         violations = validator.validate(new ValidatedObject(null));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testKnownValue_validEnumerable() {
+    void testKnownValue_validEnumerable() {
         violations = validator.validate(new ValidatedObject(CarBrand.FERRARI));
-        assertThat(violations, is(empty()));
+        assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testKnownValue_otherEnumerable() {
+    void testKnownValue_otherEnumerable() {
         ClientLocaleHolder.set(ENGLISH);
         violations = validator.validate(new ValidatedObject(CarBrand.parseLeniently("Unknown brand")));
-        assertThat(violations, hasSize(1));
-        assertThat(violations.iterator().next().getPropertyPath(), hasToString("brand"));
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("brand");
     }
 
     @Test
-    public void testKnownValue_ValidationMessage_i18n() {
+    void testKnownValue_ValidationMessage_i18n() {
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<ValidatedObject> violation = validator
                 .validate(new ValidatedObject(CarBrand.parseLeniently("Unknown brand"))).iterator().next();
-        assertThat(violation.getMessage(), equalTo("not a known constant for CarBrand"));
+        assertThat(violation.getMessage()).isEqualTo("not a known constant for CarBrand");
 
         ClientLocaleHolder.set(ClientLocaleHolder.DUTCH);
         violation = validator.validate(new ValidatedObject(CarBrand.parseLeniently("Onbekend merk"))).iterator().next();
-        assertThat(violation.getMessage(), equalTo("geen bekende constante voor CarBrand"));
+        assertThat(violation.getMessage()).isEqualTo("geen bekende constante voor CarBrand");
 
         // Does fallback to default work as expected?
         ClientLocaleHolder.set(ClientLocaleHolder.FRISIAN);
         violation = validator.validate(new ValidatedObject(CarBrand.parseLeniently("Unknown brand"))).iterator().next();
-        assertThat(violation.getMessage(), equalTo("not a known constant for CarBrand"));
+        assertThat(violation.getMessage()).isEqualTo("not a known constant for CarBrand");
     }
 
     @Test
-    public void testStandardMessages_i18n() {
+    void testStandardMessages_i18n() {
         final String englishNonNullMessage = "must not be null";
         ClientLocaleHolder.set(ENGLISH);
         ConstraintViolation<StandardMessagesObject> violation = validator.validate(new StandardMessagesObject()).iterator().next();
-        assertThat(violation.getMessage(), equalTo(englishNonNullMessage));
+        assertThat(violation.getMessage()).isEqualTo(englishNonNullMessage);
 
         ClientLocaleHolder.set(FRENCH);
         violation = validator.validate(new StandardMessagesObject()).iterator().next();
-        assertThat(violation.getMessage(), not(equalTo(englishNonNullMessage)));
+        assertThat(violation.getMessage()).isNotEqualTo(englishNonNullMessage);
     }
 
 }

--- a/enumerables-jaxrs/src/test/java/nl/talsmasoftware/enumerables/jaxrs/EnumerableParamConverterProviderTest.java
+++ b/enumerables-jaxrs/src/test/java/nl/talsmasoftware/enumerables/jaxrs/EnumerableParamConverterProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,39 +15,37 @@
  */
 package nl.talsmasoftware.enumerables.jaxrs;
 
-import org.junit.Before;
-import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.ext.ParamConverter;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class EnumerableParamConverterProviderTest {
+class EnumerableParamConverterProviderTest {
 
     EnumerableParamConverterProvider provider;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         provider = new EnumerableParamConverterProvider();
     }
 
     @Test
-    public void testNonEnumerableTypes() {
-        assertThat(provider.getConverter(null, null, null), is(nullValue()));
-        assertThat(provider.getConverter(String.class, null, null), is(nullValue()));
+    void testNonEnumerableTypes() {
+        assertThat(provider.getConverter(null, null, null)).isNull();
+        assertThat(provider.getConverter(String.class, null, null)).isNull();
     }
 
     @Test
-    public void testProvideEnumerableParamConverter() {
-        assertThat(provider.getConverter(TestEnumerable.class, null, null),
-                is(instanceOf(EnumerableParamConverter.class)));
-        assertThat(provider.getConverter(TestEnumerable.class, null, null).fromString("2nd"),
-                is(sameInstance(TestEnumerable.SECOND)));
+    void testProvideEnumerableParamConverter() {
+        ParamConverter<TestEnumerable> converter = provider.getConverter(TestEnumerable.class, null, null);
+        assertThat(converter).isInstanceOf(EnumerableParamConverter.class);
+        assertThat(converter.fromString("2nd")).isSameAs(TestEnumerable.SECOND);
     }
 
 }

--- a/enumerables-jaxrs/src/test/java/nl/talsmasoftware/enumerables/jaxrs/EnumerableParamConverterTest.java
+++ b/enumerables-jaxrs/src/test/java/nl/talsmasoftware/enumerables/jaxrs/EnumerableParamConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,58 +16,46 @@
 package nl.talsmasoftware.enumerables.jaxrs;
 
 import nl.talsmasoftware.enumerables.Enumerable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.Matchers.stringContainsInOrder;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class EnumerableParamConverterTest {
-    private static final TestEnumerable FOURTH = Enumerable.parse(TestEnumerable.class, "4th");
+class EnumerableParamConverterTest {
+    static final TestEnumerable FOURTH = Enumerable.parse(TestEnumerable.class, "4th");
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testConstructor_nullType() {
-        try {
-            new EnumerableParamConverter(null);
-            fail("Exception expected");
-        } catch (RuntimeException expected) {
-            assertThat(expected, hasToString(containsString("type is <null>")));
-        }
+    void testConstructor_nullType() {
+        assertThatThrownBy(() -> new EnumerableParamConverter(null))
+                .hasMessageContaining("type is <null>");
     }
 
     @Test
-    public void testFromString() {
+    void testFromString() {
         EnumerableParamConverter<TestEnumerable> converter = new EnumerableParamConverter<TestEnumerable>(TestEnumerable.class);
-        assertThat(converter.fromString("1st"), is(sameInstance(TestEnumerable.FIRST)));
-        assertThat(converter.fromString("2nd"), is(sameInstance(TestEnumerable.SECOND)));
-        assertThat(converter.fromString("3rd"), is(sameInstance(TestEnumerable.THIRD)));
-        assertThat(converter.fromString("4th"), is(equalTo(FOURTH)));
-        assertThat(converter.fromString(null), is(nullValue()));
+        assertThat(converter.fromString("1st")).isSameAs(TestEnumerable.FIRST);
+        assertThat(converter.fromString("2nd")).isSameAs(TestEnumerable.SECOND);
+        assertThat(converter.fromString("3rd")).isSameAs(TestEnumerable.THIRD);
+        assertThat(converter.fromString("4th")).isEqualTo(FOURTH);
+        assertThat(converter.fromString(null)).isNull();
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         EnumerableParamConverter<TestEnumerable> converter = new EnumerableParamConverter<TestEnumerable>(TestEnumerable.class);
-        assertThat(converter.toString(TestEnumerable.FIRST), is(equalTo("1st")));
-        assertThat(converter.toString(TestEnumerable.SECOND), is(equalTo("2nd")));
-        assertThat(converter.toString(TestEnumerable.THIRD), is(equalTo("3rd")));
-        assertThat(converter.toString(FOURTH), is(equalTo("4th")));
-        assertThat(converter.toString(null), is(nullValue()));
+        assertThat(converter.toString(TestEnumerable.FIRST)).isEqualTo("1st");
+        assertThat(converter.toString(TestEnumerable.SECOND)).isEqualTo("2nd");
+        assertThat(converter.toString(TestEnumerable.THIRD)).isEqualTo("3rd");
+        assertThat(converter.toString(FOURTH)).isEqualTo("4th");
+        assertThat(converter.toString(null)).isNull();
     }
 
     @Test
-    public void testForLoggingErrors() {
+    void testForLoggingErrors() {
         Logger logger = Logger.getLogger(EnumerableParamConverter.class.getName());
         logger.setLevel(Level.FINEST);
         testFromString();
@@ -76,8 +64,8 @@ public class EnumerableParamConverterTest {
     }
 
     @Test
-    public void testConverterToString() {
-        assertThat(new EnumerableParamConverter<TestEnumerable>(TestEnumerable.class),
-                hasToString(stringContainsInOrder(asList("EnumerableParamConverter", "TestEnumerable"))));
+    void testConverterToString() {
+        assertThat(new EnumerableParamConverter<>(TestEnumerable.class))
+                .hasToString("EnumerableParamConverter{%s}", TestEnumerable.class.getName());
     }
 }

--- a/enumerables-jdbi/src/test/java/nl/talsmasoftware/enumerables/jdbi/JdbiSupportTest.java
+++ b/enumerables-jdbi/src/test/java/nl/talsmasoftware/enumerables/jdbi/JdbiSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package nl.talsmasoftware.enumerables.jdbi;
 
 import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.skife.jdbi.v2.DBI;
 
 import javax.sql.DataSource;
@@ -29,24 +29,19 @@ import java.sql.Statement;
 import static nl.talsmasoftware.enumerables.jdbi.CarBrand.ASTON_MARTIN;
 import static nl.talsmasoftware.enumerables.jdbi.CarBrand.JAGUAR;
 import static nl.talsmasoftware.enumerables.jdbi.CarBrand.TESLA;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class JdbiSupportTest {
+class JdbiSupportTest {
 
     static DataSource dataSource = JdbcConnectionPool.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "user", "pwd");
 
-    @AfterClass
-    public static void shutdownDataSource() {
+    @AfterAll
+    static void shutdownDataSource() {
         ((JdbcConnectionPool) dataSource).dispose();
     }
 
-    @Before
-    public void prepareTestdata() throws SQLException {
+    @BeforeEach
+    void prepareTestdata() throws SQLException {
         Connection connection = null;
         Statement statement = null;
         try {
@@ -63,22 +58,24 @@ public class JdbiSupportTest {
     }
 
     @Test
-    public void testDummy() {
+    void testDummy() {
         DBI dbi = new DBI(dataSource);
         TestDao testDao = dbi.onDemand(TestDao.class);
 
-        assertThat(testDao.findCars(null, null), containsInAnyOrder(
-                new Car(JAGUAR, "XK", 2006),
-                new Car(TESLA, "Model S", 2015)));
-        assertThat(testDao.findCars(JAGUAR, null), contains(
-                new Car(JAGUAR, "XK", 2006)));
-        assertThat(testDao.findCars(null, "Model S"), contains(
-                new Car(TESLA, "Model S", 2015)));
-        assertThat(testDao.findCars(ASTON_MARTIN, null), hasSize(0));
+        assertThat(testDao.findCars(null, null))
+                .containsExactlyInAnyOrder(
+                        new Car(JAGUAR, "XK", 2006),
+                        new Car(TESLA, "Model S", 2015)
+                );
+        assertThat(testDao.findCars(JAGUAR, null))
+                .containsExactly(new Car(JAGUAR, "XK", 2006));
+        assertThat(testDao.findCars(null, "Model S"))
+                .containsExactly(new Car(TESLA, "Model S", 2015));
+        assertThat(testDao.findCars(ASTON_MARTIN, null)).isEmpty();
 
         // The brand should have passed the 'parse' method and therefore reuse the constant instances!
-        assertThat(testDao.findCars(null, "XK").get(0).brand, is(sameInstance(JAGUAR)));
-        assertThat(testDao.findCars(TESLA, "Model S").get(0).brand, is(sameInstance(TESLA)));
+        assertThat(testDao.findCars(null, "XK").get(0).brand).isSameAs(JAGUAR);
+        assertThat(testDao.findCars(TESLA, "Model S").get(0).brand).isSameAs(TESLA);
     }
 
 }

--- a/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPluginTest.java
+++ b/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/EnumerableJdbiPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package nl.talsmasoftware.enumerables.jdbi3;
 
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.jdbi.v3.core.Jdbi;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -29,27 +29,22 @@ import java.sql.Statement;
 import static nl.talsmasoftware.enumerables.jdbi3.CarBrand.ASTON_MARTIN;
 import static nl.talsmasoftware.enumerables.jdbi3.CarBrand.JAGUAR;
 import static nl.talsmasoftware.enumerables.jdbi3.CarBrand.TESLA;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sjoerd Talsma
  */
-public class EnumerableJdbiPluginTest {
+class EnumerableJdbiPluginTest {
 
     static DataSource dataSource = JdbcConnectionPool.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "user", "pwd");
 
-    @AfterClass
-    public static void shutdownDataSource() {
+    @AfterAll
+    static void shutdownDataSource() {
         ((JdbcConnectionPool) dataSource).dispose();
     }
 
-    @Before
-    public void prepareTestdata() throws SQLException {
+    @BeforeEach
+    void prepareTestdata() throws SQLException {
         Connection connection = null;
         Statement statement = null;
         try {
@@ -66,21 +61,23 @@ public class EnumerableJdbiPluginTest {
     }
 
     @Test
-    public void testCars() {
+    void testCars() {
         CarDao carDao = Jdbi.create(dataSource).installPlugins().onDemand(CarDao.class);
 
-        assertThat(carDao.findCars(null, null), containsInAnyOrder(
-                new Car(JAGUAR, "XK", 2006),
-                new Car(TESLA, "Model S", 2015)));
-        assertThat(carDao.findCars(JAGUAR, null), contains(
-                new Car(JAGUAR, "XK", 2006)));
-        assertThat(carDao.findCars(null, "Model S"), contains(
-                new Car(TESLA, "Model S", 2015)));
-        assertThat(carDao.findCars(ASTON_MARTIN, null), hasSize(0)); // unfortunately ;-)
+        assertThat(carDao.findCars(null, null))
+                .containsExactlyInAnyOrder(
+                        new Car(JAGUAR, "XK", 2006),
+                        new Car(TESLA, "Model S", 2015)
+                );
+        assertThat(carDao.findCars(JAGUAR, null)).containsExactly(
+                new Car(JAGUAR, "XK", 2006));
+        assertThat(carDao.findCars(null, "Model S")).containsExactly(
+                new Car(TESLA, "Model S", 2015));
+        assertThat(carDao.findCars(ASTON_MARTIN, null)).isEmpty(); // unfortunately ;-)
 
         // The brand should have passed the 'parse' method and therefore reuse the constant instances!
-        assertThat(carDao.findCars(null, "XK").get(0).brand, is(sameInstance(JAGUAR)));
-        assertThat(carDao.findCars(TESLA, "Model S").get(0).brand, is(sameInstance(TESLA)));
+        assertThat(carDao.findCars(null, "XK").get(0).brand).isSameAs(JAGUAR);
+        assertThat(carDao.findCars(TESLA, "Model S").get(0).brand).isSameAs(TESLA);
     }
 
 }

--- a/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/Jdbi3SupportTest.java
+++ b/enumerables-jdbi3/src/test/java/nl/talsmasoftware/enumerables/jdbi3/Jdbi3SupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package nl.talsmasoftware.enumerables.jdbi3;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -30,24 +30,19 @@ import java.sql.Statement;
 import static nl.talsmasoftware.enumerables.jdbi3.CarBrand.ASTON_MARTIN;
 import static nl.talsmasoftware.enumerables.jdbi3.CarBrand.JAGUAR;
 import static nl.talsmasoftware.enumerables.jdbi3.CarBrand.TESLA;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class Jdbi3SupportTest {
+class Jdbi3SupportTest {
 
     static DataSource dataSource = JdbcConnectionPool.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "user", "pwd");
 
-    @AfterClass
-    public static void shutdownDataSource() {
+    @AfterAll
+    static void shutdownDataSource() {
         ((JdbcConnectionPool) dataSource).dispose();
     }
 
-    @Before
-    public void prepareTestdata() throws SQLException {
+    @BeforeEach
+    void prepareTestdata() throws SQLException {
         Connection connection = null;
         Statement statement = null;
         try {
@@ -64,23 +59,25 @@ public class Jdbi3SupportTest {
     }
 
     @Test
-    public void testDummy() {
+    void testDummy() {
         Jdbi jdbi = Jdbi.create(dataSource);
         jdbi.installPlugin(new SqlObjectPlugin());
         TestDao testDao = jdbi.onDemand(TestDao.class);
 
-        assertThat(testDao.findCars(null, null), containsInAnyOrder(
-                new Car(JAGUAR, "XK", 2006),
-                new Car(TESLA, "Model S", 2015)));
-        assertThat(testDao.findCars(JAGUAR, null), contains(
-                new Car(JAGUAR, "XK", 2006)));
-        assertThat(testDao.findCars(null, "Model S"), contains(
-                new Car(TESLA, "Model S", 2015)));
-        assertThat(testDao.findCars(ASTON_MARTIN, null), hasSize(0));
+        assertThat(testDao.findCars(null, null))
+                .containsExactlyInAnyOrder(
+                        new Car(JAGUAR, "XK", 2006),
+                        new Car(TESLA, "Model S", 2015)
+                );
+        assertThat(testDao.findCars(JAGUAR, null)).containsExactly(
+                new Car(JAGUAR, "XK", 2006));
+        assertThat(testDao.findCars(null, "Model S")).containsExactly(
+                new Car(TESLA, "Model S", 2015));
+        assertThat(testDao.findCars(ASTON_MARTIN, null)).isEmpty();
 
         // The brand should have passed the 'parse' method and therefore reuse the constant instances!
-        assertThat(testDao.findCars(null, "XK").get(0).brand, is(sameInstance(JAGUAR)));
-        assertThat(testDao.findCars(TESLA, "Model S").get(0).brand, is(sameInstance(TESLA)));
+        assertThat(testDao.findCars(null, "XK").get(0).brand).isSameAs(JAGUAR);
+        assertThat(testDao.findCars(TESLA, "Model S").get(0).brand).isSameAs(TESLA);
     }
 
 }

--- a/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/EnumerableModelConverterTest.java
+++ b/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/EnumerableModelConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +21,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.converter.ModelConverters;
 import io.swagger.models.Model;
 import org.json.JSONException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Locale;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasKey;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnumerableModelConverterTest {
+class EnumerableModelConverterTest {
 
     final ObjectMapper mapper = new ObjectMapper()
             .findAndRegisterModules()
@@ -44,28 +43,28 @@ public class EnumerableModelConverterTest {
 
     static Locale previousDefault;
 
-    @BeforeClass
-    public static void captureDefaultLocale() {
+    @BeforeAll
+    static void captureDefaultLocale() {
         previousDefault = Locale.getDefault();
     }
 
-    @AfterClass
-    public static void restoreDefaultLocale() {
+    @AfterAll
+    static void restoreDefaultLocale() {
         Locale.setDefault(previousDefault);
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         ModelConverters.getInstance().addConverter(converter);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         ModelConverters.getInstance().removeConverter(converter);
     }
 
     @Test
-    public void testSwaggerModelForCar() throws JsonProcessingException, JSONException {
+    void testSwaggerModelForCar() throws JsonProcessingException, JSONException {
         Locale.setDefault(Locale.ENGLISH);
         String expectedCarModel = "{" +
                 "\"type\": \"object\"," +
@@ -84,10 +83,10 @@ public class EnumerableModelConverterTest {
         Map<String, Model> swagger = ModelConverters.getInstance().readAll(Car.class);
         // System.out.println(mapper.writeValueAsString(swagger));
 
-        assertThat(swagger, hasKey("Car"));
+        assertThat(swagger).containsKey("Car");
         JSONAssert.assertEquals(expectedCarModel, mapper.writeValueAsString(swagger.get("Car")), false);
 
-        assertThat(swagger, hasKey("CarBrand"));
+        assertThat(swagger).containsKey("CarBrand");
         JSONAssert.assertEquals(expectedCarBrandModel, mapper.writeValueAsString(swagger.get("CarBrand")), true);
     }
 

--- a/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/SwaggerModelWithoutConverterTest.java
+++ b/enumerables-swagger/src/test/java/nl/talsmasoftware/enumerables/swagger/SwaggerModelWithoutConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,30 +21,29 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.converter.ModelConverters;
 import io.swagger.models.Model;
 import org.json.JSONException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasKey;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class SwaggerModelWithoutConverterTest {
+class SwaggerModelWithoutConverterTest {
 
     final ObjectMapper mapper = new ObjectMapper()
             .findAndRegisterModules()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-    @Before
-    @After
-    public void removeEnumerableModelConverter() {
+    @BeforeEach
+    @AfterEach
+    void removeEnumerableModelConverter() {
         ModelConverters.getInstance().removeConverter(new EnumerableModelConverter());
     }
 
     @Test
-    public void testSwaggerModelForCar() throws JsonProcessingException, JSONException {
+    void testSwaggerModelForCar() throws JsonProcessingException, JSONException {
         String expectedCarModel = "{" +
                 "\"type\": \"object\"," +
                 "\"properties\": {" +
@@ -63,10 +62,10 @@ public class SwaggerModelWithoutConverterTest {
         Map<String, Model> swagger = ModelConverters.getInstance().readAll(Car.class);
         // System.out.println(mapper.writeValueAsString(swagger));
 
-        assertThat(swagger, hasKey("Car"));
+        assertThat(swagger).containsKey("Car");
         JSONAssert.assertEquals(expectedCarModel, mapper.writeValueAsString(swagger.get("Car")), false);
 
-        assertThat(swagger, hasKey("CarBrand"));
+        assertThat(swagger).containsKey("CarBrand");
         JSONAssert.assertEquals(expectedCarBrandModel, mapper.writeValueAsString(swagger.get("CarBrand")), true);
     }
 

--- a/enumerables/src/test/java/nl/talsmasoftware/enumerables/CarBrandTest.java
+++ b/enumerables/src/test/java/nl/talsmasoftware/enumerables/CarBrandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2025 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,49 +15,47 @@
  */
 package nl.talsmasoftware.enumerables;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic 'sanity-check' for the parseLeniently method that is being used in other tests.
  *
  * @author Sjoerd Talsma
  */
-public class CarBrandTest {
+class CarBrandTest {
 
     @Test
-    public void testParseLeniently_null() {
-        assertThat(CarBrand.parseLeniently(null), is(nullValue()));
+    void testParseLeniently_null() {
+        assertThat(CarBrand.parseLeniently(null)).isNull();
     }
 
     @Test
-    public void testParseLeniently_empty() {
-        assertThat(CarBrand.parseLeniently(""), is(not(nullValue())));
-        assertThat(CarBrand.parseLeniently("").name(), is(nullValue()));
-        assertThat(CarBrand.parseLeniently("").getValue(), is(equalTo("")));
+    void testParseLeniently_empty() {
+        CarBrand result = CarBrand.parseLeniently("");
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isNull();
+        assertThat(result.getValue()).isEmpty();
     }
 
     @Test
-    public void testParseLeniently() {
-        assertThat(CarBrand.parseLeniently("citroen"), is(sameInstance(CarBrand.CITROEN)));
-        assertThat(CarBrand.parseLeniently("mercedesbenz"), is(sameInstance(CarBrand.MERCEDES_BENZ)));
-        assertThat(CarBrand.parseLeniently("mercedes benz"), is(sameInstance(CarBrand.MERCEDES_BENZ)));
-        assertThat(CarBrand.parseLeniently("gm"), is(sameInstance(CarBrand.GM)));
-        assertThat(CarBrand.parseLeniently("generalMotors"), is(sameInstance(CarBrand.GM)));
+    void testParseLeniently() {
+        assertThat(CarBrand.parseLeniently("citroen")).isSameAs(CarBrand.CITROEN);
+        assertThat(CarBrand.parseLeniently("mercedesbenz")).isSameAs(CarBrand.MERCEDES_BENZ);
+        assertThat(CarBrand.parseLeniently("mercedes benz")).isSameAs(CarBrand.MERCEDES_BENZ);
+        assertThat(CarBrand.parseLeniently("gm")).isSameAs(CarBrand.GM);
+        assertThat(CarBrand.parseLeniently("generalMotors")).isSameAs(CarBrand.GM);
     }
 
     @Test
-    public void testParseLeniently_notFound() {
+    void testParseLeniently_notFound() {
         CarBrand rover = CarBrand.parseLeniently("Rover");
-        assertThat(rover, is(not(nullValue())));
-        assertThat(rover.name(), is(nullValue()));
-        assertThat(rover.getValue(), is(equalTo("Rover")));
-        assertThat(CarBrand.parseLeniently("Rover"), is(equalTo(rover)));
+        assertThat(rover).isNotNull();
+        assertThat(rover.name()).isNull();
+        assertThat(rover.getValue()).isEqualTo("Rover");
+        assertThat(CarBrand.parseLeniently("Rover"))
+                .isNotSameAs(rover)
+                .isEqualTo(rover);
     }
 }

--- a/enumerables/src/test/java/nl/talsmasoftware/enumerables/EnumerableTest.java
+++ b/enumerables/src/test/java/nl/talsmasoftware/enumerables/EnumerableTest.java
@@ -32,7 +32,7 @@ import static java.lang.Integer.signum;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SuppressWarnings({"unused", "deprecation"})
+@SuppressWarnings({"unused"})
 class EnumerableTest {
 
     static final class BigCo extends Enumerable {
@@ -228,7 +228,7 @@ class EnumerableTest {
 
     @Test
     void testOrdinal() {
-        assertThat(Fruit.APPLE.ordinal()).isEqualTo(0);
+        assertThat(Fruit.APPLE.ordinal()).isZero();
         assertThat(Fruit.ORANGE.ordinal()).isEqualTo(1);
         assertThat(new Fruit(Fruit.APPLE.getValue()).ordinal()).isEqualTo(0);
         assertThat(new Fruit("Pineapple").ordinal()).isEqualTo(Integer.MAX_VALUE);
@@ -261,7 +261,7 @@ class EnumerableTest {
 
     @Test
     void testCompareTo() {
-        // Clearly an orange is bigger than an apple? ;-)
+        // An orange is bigger than an apple? ;-)
         assertThat(signum(Fruit.APPLE.compareTo(Fruit.ORANGE))).isEqualTo(-1);
         assertThat(signum(Fruit.APPLE.compareTo(Fruit.APPLE))).isEqualTo(0);
         assertThat(signum(Fruit.ORANGE.compareTo(Fruit.ORANGE))).isEqualTo(0);

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
 
         <jackson2.version>2.19.0</jackson2.version>
 
-        <junit.version>4.13.2</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.17.0</mockito.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -98,22 +97,38 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
+        <!--
+                <dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>${junit.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.hamcrest</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+        -->
+        <!--
+                <dependency>
                     <groupId>org.hamcrest</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+                    <artifactId>hamcrest</artifactId>
+                    <version>${hamcrest.version}</version>
+                    <scope>test</scope>
+                </dependency>
+        -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -453,27 +468,31 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <header>${root.basedir}/.mvn/license/header.txt</header>
+                            <strictCheck>true</strictCheck>
                             <properties>
                                 <owner>${project.organization.name}</owner>
                             </properties>
                             <mapping>
                                 <java>SLASHSTAR_STYLE</java>
                             </mapping>
-                            <excludes>
-                                <exclude>.gitignore</exclude>
-                                <exclude>.github/**</exclude>
-                                <exclude>.mvn/**</exclude>
-                                <exclude>mvnw*</exclude>
-                                <exclude>**/.idea/**</exclude>
-                                <exclude>LICENSE</exclude>
-                                <exclude>**/*.md</exclude>
-                                <exclude>**/*.puml</exclude>
-                                <exclude>**/*.svg</exclude>
-                                <exclude>src/main/resources/**</exclude>
-                                <exclude>src/test/resources/**</exclude>
-                            </excludes>
-                            <strictCheck>true</strictCheck>
+                            <licenseSets>
+                                <licenseSet>
+                                    <header>${root.basedir}/.mvn/license/header.txt</header>
+                                    <excludes>
+                                        <exclude>.gitignore</exclude>
+                                        <exclude>.github/**</exclude>
+                                        <exclude>.mvn/**</exclude>
+                                        <exclude>mvnw*</exclude>
+                                        <exclude>**/.idea/**</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <exclude>**/*.md</exclude>
+                                        <exclude>**/*.puml</exclude>
+                                        <exclude>**/*.svg</exclude>
+                                        <exclude>src/main/resources/**</exclude>
+                                        <exclude>src/test/resources/**</exclude>
+                                    </excludes>
+                                </licenseSet>
+                            </licenseSets>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Updates the tests across several modules to use JUnit Jupiter and AssertJ, while also updating copyright years.

- Updated JUnit imports and annotations (e.g. `@BeforeEach`, `@AfterAll`, etc.)
- Replaced Hamcrest assertions with AssertJ assertions
- Updated file headers to reflect copyright changes to 2025

This fixes #173 